### PR TITLE
Tweak selection color to be more distinct

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -21,7 +21,7 @@ endif
 let g:colors_name = "dracula"
 
 hi Cursor ctermfg=17 ctermbg=231 cterm=NONE guifg=#282a36 guibg=#f8f8f0 gui=NONE
-hi Visual ctermfg=NONE ctermbg=236 cterm=NONE guifg=NONE guibg=#44475a gui=NONE
+hi Visual ctermfg=NONE ctermbg=241 cterm=NONE guifg=NONE guibg=#44475a gui=NONE
 hi CursorLine ctermbg=234 cterm=NONE guifg=NONE guibg=#44475a gui=NONE
 hi CursorColumn ctermfg=NONE ctermbg=236 cterm=NONE guifg=NONE guibg=#3d3f49 gui=NONE
 hi ColorColumn ctermfg=NONE ctermbg=236 cterm=NONE guifg=NONE guibg=#3d3f49 gui=NONE


### PR DESCRIPTION
## Tweak Vim selection color (visual mode)

Current color is not so distinct on some displays, see https://github.com/zenorocha/dracula-theme/issues/156.

## Screenshots

The selection color is alike the background color, making it difficult to distinct:

<img width="745" alt="before" src="https://cloud.githubusercontent.com/assets/1391/15598170/6e2abf48-2412-11e6-9d7a-6a710443fbd5.png">

With the change, it looks more obvious:

<img width="745" alt="after" src="https://cloud.githubusercontent.com/assets/1391/15598183/7ecd6e04-2412-11e6-921d-30cd6138b3cc.png">

I believe this really depends on the display and `personal eye` but perhaps this tiny change would make the selection more obvious.