### PR TITLE
Remove background color for NonText lines

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -56,7 +56,7 @@ hi Function ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
 hi Identifier ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
 hi Keyword ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 hi Label ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-hi NonText ctermfg=231 ctermbg=235 cterm=NONE guifg=#525563 guibg=#282a36 gui=NONE
+hi NonText ctermfg=231 ctermbg=NONE cterm=NONE guifg=#525563 guibg=#282a36 gui=NONE
 hi Number ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
 hi Operator ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 hi PreProc ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE


### PR DESCRIPTION
To have same background color for both text and blank lines.

Lines with texts are blank lines are having different background colors. (blank lines have `235`, text lines don't have color specified it's using the default background color (from Terminal theme?).

## Before

<img width="626" alt="screen shot 2016-05-30 at 17 40 02" src="https://cloud.githubusercontent.com/assets/1391/15644487/579a0ae4-268e-11e6-9044-65952568cea3.png">

## After

<img width="626" alt="screen shot 2016-05-30 at 17 40 31" src="https://cloud.githubusercontent.com/assets/1391/15644507/70cd282a-268e-11e6-8d4b-44d026e87eea.png">
