### PR TITLE
Fix Cursorline issue.

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -57,12 +57,12 @@ hi Function ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
 hi Identifier ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
 hi Keyword ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 hi Label ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-hi NonText guifg=#f8f8f2 guibg=#1e1f29 gui=NONE
+hi NonText ctermfg=231 ctermbg=NONE cterm=NONE guifg=#525563 guibg=NONE gui=NONE
 hi Number ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
 hi Operator ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 hi PreProc ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 hi Special ctermfg=231 ctermbg=NONE cterm=NONE guifg=#f8f8f2 guibg=NONE gui=NONE
-hi SpecialKey ctermfg=59 ctermbg=236 cterm=NONE guifg=#3b3a32 guibg=#3d3f49 gui=NONE
+hi SpecialKey ctermfg=231 ctermbg=235 cterm=NONE guifg=#525563 guibg=NONE gui=NONE
 hi Statement ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 hi StorageClass ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
 hi String ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE


### PR DESCRIPTION
Actually, the fix is much simpler, and probably introduced by me (sorry about that.)

The `NonText`, and `SpecialKey` entries don't need to have `guibg` for each one of them. This actually overrides what's set in `CursorLine` (a lighter `guibg`).

Before:
![screen shot 2016-08-26 at 16 54 37](https://cloud.githubusercontent.com/assets/6126301/18018670/830e4644-6bae-11e6-92e4-5b629b14adae.png)

After:
![screen shot 2016-08-26 at 16 55 04](https://cloud.githubusercontent.com/assets/6126301/18018676/894d73ea-6bae-11e6-8fef-15aad7e4b0ee.png)
