### PR TITLE
Fix cterm background color

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -38,7 +38,7 @@ hi Directory ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NO
 hi Folded ctermfg=61 ctermbg=235 cterm=NONE guifg=#6272a4 guibg=#282a36 gui=NONE
 hi SignColumn ctermfg=246 ctermbg=235 cterm=NONE guifg=#909194 guibg=#44475a gui=NONE
 hi FoldColmun ctermfg=246 ctermbg=235 cterm=NONE guifg=#909194 guibg=#44475a gui=NONE
-hi Normal guifg=#f8f8f2 guibg=#282a36 gui=NONE
+hi Normal ctermfg=254 ctermbg=234 cterm=NONE guifg=#f8f8f2 guibg=#282a36 gui=NONE
 hi Boolean ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
 hi Character ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
 hi Comment ctermfg=61 ctermbg=NONE cterm=NONE guifg=#6272a4 guibg=NONE gui=NONE


### PR DESCRIPTION
If the terminal settings are set transparent background that affects the background of Dracula colorscheme.

There is no preview color to cterm, then used the more like that found.

![before](http://i.imgur.com/NWMtVhv.png)
![after](http://i.imgur.com/paDcPKg.png)