### PR TITLE
Indicate in airline that the current buffer has unsaved changes

### DIFF
--- a/autoload/airline/themes/dracula.vim
+++ b/autoload/airline/themes/dracula.vim
@@ -31,6 +31,9 @@ let s:guiBlack = "#282a36"
 let s:ctermWhite = "15"
 let s:ctermBlack = "16"
 
+let s:ctermChangedColor = "59"
+let s:guiChangedColor = "#5f5f5f"
+
 " Normal mode
 let s:N1 = [ s:guiBlack , s:gui08 , s:ctermBlack , s:cterm08 ]
 let s:N2 = [ s:guiWhite , s:gui02 , s:ctermWhite , s:cterm02 ]
@@ -50,6 +53,9 @@ let s:V3 = [ s:guiWhite , s:gui01 , s:ctermWhite, s:cterm01 ]
 let s:R1 = [ s:guiBlack , s:gui05 , s:ctermWhite, s:cterm05 ]
 let s:R2 = [ s:guiWhite , s:gui02 , s:ctermWhite, s:cterm02 ]
 let s:R3 = [ s:guiWhite , s:gui01 , s:ctermWhite, s:cterm01 ]
+
+" File changed
+let s:changed = [ s:guiWhite , s:guiChangedColor , s:ctermWhite , s:ctermChangedColor ]
 
 let g:airline#themes#dracula#palette = {}
 let g:airline#themes#dracula#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
@@ -77,6 +83,12 @@ let g:airline#themes#dracula#palette.normal.airline_error = s:ERROR
 let g:airline#themes#dracula#palette.insert.airline_error = s:ERROR
 let g:airline#themes#dracula#palette.visual.airline_error = s:ERROR
 let g:airline#themes#dracula#palette.replace.airline_error = s:ERROR
+
+" File modified and not saved
+let g:airline#themes#dracula#palette.normal_modified = airline#themes#generate_color_map(s:N1, s:N2, s:changed)
+let g:airline#themes#dracula#palette.insert_modified = airline#themes#generate_color_map(s:I1, s:I2, s:changed)
+let g:airline#themes#dracula#palette.replace_modified = airline#themes#generate_color_map(s:R1, s:R2, s:changed)
+let g:airline#themes#dracula#palette.visual_modified = airline#themes#generate_color_map(s:V1, s:V2, s:changed)
 
 " CtrlP
 if !get(g:, 'loaded_ctrlp', 0)


### PR DESCRIPTION
Color the airline statusbar in gray when there are unsaved changes (all modes).

![patched_airline](https://cloud.githubusercontent.com/assets/827143/20534809/dd2009fa-b0e2-11e6-82c9-032ad6e9390f.gif)


**Before**:
<img width="1440" alt="before" src="https://cloud.githubusercontent.com/assets/827143/20535241/5a737a3a-b0e4-11e6-8544-912429d48f92.png">


**After**:
<img width="1440" alt="after" src="https://cloud.githubusercontent.com/assets/827143/20535250/609acab2-b0e4-11e6-91fc-a635a5c737a3.png">

