### PR TITLE
Enhancement: lighter the foreground of airline

### DIFF
--- a/autoload/airline/themes/dracula.vim
+++ b/autoload/airline/themes/dracula.vim
@@ -59,7 +59,7 @@ let g:airline#themes#dracula#palette.visual = airline#themes#generate_color_map(
 let g:airline#themes#dracula#palette.replace = airline#themes#generate_color_map(s:R1, s:R2, s:R3)
 
 " Inactive mode
-let s:IN1 = [ s:gui04 , s:gui02 , s:cterm04 , s:cterm02 ]
+let s:IN1 = [ s:gui04 , s:guiWhite , s:cterm04 , s:ctermWhite ]
 let s:IN2 = [ s:gui04 , s:gui01 , s:cterm04  , s:cterm01 ]
 let s:IA = [ s:IN1[1] , s:IN2[1] , s:IN1[3] , s:IN2[3] , '' ]
 let g:airline#themes#dracula#palette.inactive = airline#themes#generate_color_map(s:IA, s:IA, s:IA)


### PR DESCRIPTION
Lighter the foreground of the airline bar of inactive panels, make it more clear from the dark background.
Old:
<img width="468" alt="old" src="https://cloud.githubusercontent.com/assets/3270410/20865651/a4a10a94-ba0f-11e6-9089-2445ca48bd03.png">
New:
<img width="679" alt="new" src="https://cloud.githubusercontent.com/assets/3270410/20865650/a46c2734-ba0f-11e6-991c-e6da3a8c1e80.png">

