### PR TITLE
Set guifg for rubyInstanceVariable

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -78,7 +78,7 @@ hi rubySymbol ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=N
 hi rubyConstant ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic
 hi rubyStringDelimiter ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
 hi rubyBlockParameter ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic
-hi rubyInstanceVariable ctermfg=203 ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+hi rubyInstanceVariable ctermfg=203 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=NONE
 hi rubyInclude ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 hi rubyGlobalVariable ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
 hi rubyRegexp ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE


### PR DESCRIPTION
There's no highlight for rubyInstanceVariable in neovim.
Referenced to other editor's syntax highlight and add #ffb86c to rubyInstanceVariable guifg.

Before:
![2017-05-05 8 29 09](https://cloud.githubusercontent.com/assets/4735528/25745482/a562424c-31d1-11e7-832b-2eeb99fd444e.png)

After:
![2017-05-05 8 29 39](https://cloud.githubusercontent.com/assets/4735528/25745484/ab72a956-31d1-11e7-93e9-9a2ec518d5dc.png)
