### PR TITLE
Revert "Fix cterm background color"

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -39,7 +39,7 @@ hi Directory ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NO
 hi Folded ctermfg=61 ctermbg=235 cterm=NONE guifg=#6272a4 guibg=#282a36 gui=NONE
 hi SignColumn ctermfg=246 ctermbg=235 cterm=NONE guifg=#909194 guibg=#44475a gui=NONE
 hi FoldColmun ctermfg=246 ctermbg=235 cterm=NONE guifg=#909194 guibg=#44475a gui=NONE
-hi Normal ctermfg=254 ctermbg=234 cterm=NONE guifg=#f8f8f2 guibg=#282a36 gui=NONE
+hi Normal guifg=#f8f8f2 guibg=#282a36 gui=NONE
 hi Boolean ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
 hi Character ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
 hi Comment ctermfg=61 ctermbg=NONE cterm=NONE guifg=#6272a4 guibg=NONE gui=NONE


### PR DESCRIPTION
This reverts commit https://github.com/dracula/vim/commit/38d5c9b7335c02b8e3f77f83748103426e176cf9 (https://github.com/dracula/vim/pull/19) to fix #29 .

Setting termcolors on that commit has some problems:

- Only setting highlights to `Normal` makes weird appearance (described in #29)
- At least termcolor 234 has conflicts with `CursorLine` / `CursorColumn`, so you cannot see them
- Maybe most importantly, termcolor 234 is not a typical Dracula background color. it differs from not only other stuffs' Dracula themes but also Vim with GUI using Dracula theme

So I think that reverting that commit and leaving normal bgcolor to user's terminal setting are the best for the moment.

