### PR TITLE
fix bug from background color on neovim

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -12,6 +12,7 @@
 " @author Zeno Rocha <hi@zenorocha.com>
 
 set background=dark
+set termguicolors
 highlight clear
 
 if exists("syntax_on")


### PR DESCRIPTION
Bug fixes: background color not displaying in neovim
This commit fixes #11 

Solution from [here](https://github.com/dracula/vim/issues/11#issuecomment-308722119), but @dukebarman didn't commit it, I have to push this. 
Thank you, dukebarman.

Environment:
SSH to my arch computer from windows 10 with gitbash.
neovim ( on arch ) version: V 0.2.0

Oh, my english sucks.

above: before
below: after
![image](https://user-images.githubusercontent.com/15802727/27765080-7a2e962a-5edb-11e7-8e97-fcc3a866c3ff.png)
![image](https://user-images.githubusercontent.com/15802727/27765102-d29f80b2-5edb-11e7-983b-f43a231a25d1.png)

