### PR TITLE
fix typo foldcolumn

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -38,7 +38,7 @@ hi Search ctermfg=17 ctermbg=84 cterm=none guifg=#282a36 guibg=#50fa7b gui=none
 hi Directory ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
 hi Folded ctermfg=61 ctermbg=235 cterm=NONE guifg=#6272a4 guibg=#282a36 gui=NONE
 hi SignColumn ctermfg=246 ctermbg=235 cterm=NONE guifg=#909194 guibg=#44475a gui=NONE
-hi FoldColmun ctermfg=246 ctermbg=235 cterm=NONE guifg=#909194 guibg=#44475a gui=NONE
+hi FoldColumn ctermfg=246 ctermbg=235 cterm=NONE guifg=#909194 guibg=#44475a gui=NONE
 hi Normal guifg=#f8f8f2 guibg=#282a36 gui=NONE
 hi Boolean ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
 hi Character ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE


### PR DESCRIPTION
the foldcolumn color cofig doesn't take effect because of typo (env: centos7, vim7.4)

above: before
below: after

![before](https://user-images.githubusercontent.com/6105214/28119808-ae915ca2-6748-11e7-9c9c-fb1e936670dd.png)

![after](https://user-images.githubusercontent.com/6105214/28119819-ba46af2a-6748-11e7-9d32-4fc290868ba8.png)

