### PR TITLE
Add terminal colors for neovim

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -163,6 +163,26 @@ hi markdownUrl ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=
 hi markdownUrlTitleDelimiter ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
 " }}}
 
+" Neovim Terminal Colors {{{
+if has("nvim")
+  let g:terminal_color_0 = "#000000"
+  let g:terminal_color_1 = "#FF5555"
+  let g:terminal_color_2 = "#50FA7B"
+  let g:terminal_color_3 = "#F1FA8C"
+  let g:terminal_color_4 = "#BD93F9"
+  let g:terminal_color_5 = "#FF79C6"
+  let g:terminal_color_6 = "#8BE9FD"
+  let g:terminal_color_7 = "#BFBFBF"
+  let g:terminal_color_8 = "#4D4D4D"
+  let g:terminal_color_9 = "#FF6E67"
+  let g:terminal_color_10 = "#5AF78E"
+  let g:terminal_color_11 = "#F4F99D"
+  let g:terminal_color_12 = "#CAA9FA"
+  let g:terminal_color_13 = "#FF92D0"
+  let g:terminal_color_14 = "#9AEDFE"
+  let g:terminal_color_15 = "#E6E6E6"
+endif
+" }}}
 
 "
 "cygwin has an annoying behavior where it resets background to light


### PR DESCRIPTION
Neovim has support for embedded terminals. But the colors do not inherit from the parent shell

https://github.com/neovim/neovim/issues/2897#issuecomment-115464516
https://neovim.io/doc/user/nvim_terminal_emulator.html

before:
<img width="547" alt="ddd11" src="https://user-images.githubusercontent.com/281076/29159658-eaac2dfc-7de1-11e7-9a25-c081d1ca8137.png">

after:
<img width="608" alt="ddd222" src="https://user-images.githubusercontent.com/281076/29159664-f18608dc-7de1-11e7-8fdd-cf95549d4d92.png">
