### PR TITLE
fix(colors): adjust SpellBad highlighting

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -66,6 +66,7 @@ hi SpecialKey ctermfg=231 ctermbg=235 cterm=NONE guifg=#525563 guibg=NONE gui=NO
 hi Statement ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 hi StorageClass ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
 hi String ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
+hi SpellBad ctermfg=red ctermbg=NONE cterm=underline
 hi Tag ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 hi Title ctermfg=231 ctermbg=NONE cterm=bold guifg=#f8f8f2 guibg=NONE gui=bold
 hi Todo ctermfg=61 ctermbg=NONE cterm=inverse,bold guifg=#6272a4 guibg=NONE gui=inverse,bold


### PR DESCRIPTION
Define `SpellBad` highlighting rule to improve readability.

| Before | After|
| --- | --- |
| ![screen shot 2017-12-28 at 17 01 17](https://user-images.githubusercontent.com/647035/34415844-0fd0f2ac-ebf1-11e7-8a18-15703f997fa1.png) | ![screen shot 2017-12-28 at 17 02 05](https://user-images.githubusercontent.com/647035/34415856-20a2c1dc-ebf1-11e7-8b60-ea9b4c323542.png)|

Closes #47