### PR TITLE
Add SpecialComment highlight

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -62,6 +62,7 @@ hi Number ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
 hi Operator ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 hi PreProc ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 hi Special ctermfg=231 ctermbg=NONE cterm=NONE guifg=#f8f8f2 guibg=NONE gui=NONE
+hi SpecialComment ctermfg=61 ctermbg=NONE cterm=NONE guifg=#6272a4 guibg=NONE gui=NONE
 hi SpecialKey ctermfg=231 ctermbg=235 cterm=NONE guifg=#525563 guibg=NONE gui=NONE
 hi Statement ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 hi StorageClass ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic


### PR DESCRIPTION
Highlight `SpecialComment` in the same way as `Comment`.

#### Before
![screenshot_20180110_121500](https://user-images.githubusercontent.com/21980157/34754250-e9bec148-f5ff-11e7-8ef1-81d1a58ace6b.png)

#### After
![screenshot_20180110_121337](https://user-images.githubusercontent.com/21980157/34754257-ef131504-f5ff-11e7-8cce-c27ec5fb33c6.png)
