### PR TITLE
Add some OCaml specific adjustments

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -162,6 +162,17 @@ hi markdownHeadingDelimiter ctermfg=117 ctermbg=NONE cterm=bold guifg=#8be9fd gu
 hi markdownUrl ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
 hi markdownUrlTitleDelimiter ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
 " }}}
+" OCaml {{{
+hi ocamlModule ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
+hi ocamlConstructor ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
+hi ocamlType ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
+hi ocamlModPath ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
+hi ocamlTodo ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic
+hi ocamlLabel ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
+hi ocamlFullMod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
+hi ocamlWith ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
+hi ocamlUnit ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+" }}}
 
 
 "


### PR DESCRIPTION
Just some general updates to improve highlighting of OCaml.  I've been using it for the last two weeks and am quite happy with the changes.

- before
<img width="746" alt="screen shot 2018-02-03 at 4 34 05 pm" src="https://user-images.githubusercontent.com/630055/35771789-68e5e4c0-0900-11e8-92b3-626efb2d1892.png">

- after
<img width="750" alt="screen shot 2018-02-03 at 4 34 58 pm" src="https://user-images.githubusercontent.com/630055/35771788-68db26fc-0900-11e8-9a9d-64327d2d4bcd.png">