### PR TITLE
Massive theme overhaul

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,1 +1,45 @@
-> If you're reporting an UI issue, make sure you take a screenshot that shows the actual bug.
+<!--
+Thanks for your interest in reporting an issue.
+
+Before submitting, please refer to the following common issues and solutions:
+
+Running vim in a terminal?
+- Try adding `set termguicolors` to your vimrc.
+
+Running vim with tmux?
+- Be sure you have terminal-overrides to enable truecolor (if supported in your term)
+- Be sure your `default-terminal` is set to, ideally, `tmux-256color`. If your OS doesn't
+  have `tmux-256color` terminfo files, google them and add them using `tic`
+
+Having issues with font styles (italic, bold, underline)?
+- Be sure your terminal supports these styles.
+- If running tmux, see tmux section.
+- If all else fails, disable the style by setting `let g:dracula_<style-name> = 0`
+  in your vimrc, where `<style-name>` is one of (`italic`, `bold`, `underline`, `undercurl`, `inverse`)
+
+If the above did not resolve your issue, please complete all fields of the form below.
+-->
+
+### What happened
+
+### What I expected to happen
+
+### Screenshot
+
+### Machine Info
+<!--
+if on a *nix system, please provide the output of `uname -a` for OS field
+-->
+- **Vim type (`vim`/`gvim`/`neovim`)**:
+- **Vim version**:
+- **OS**:
+- **Terminal/Terminal Emulator/VTE**:
+- **`TERM` environment variable**:
+
+### Additional Info
+<!--
+If using Tmux, please provide the output of `tmux info`
+
+If having issues with text rendering, please provide the output of `infocmp`
+-->
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,5 @@
-> If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.
+<!--
+If you're fixing a UI issue, make sure you take two screenshots.
+One that shows the actual bug and another that shows how you fixed it.
+-->
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -1,3 +1,4 @@
+" vim: fdm=marker:
 " Dracula Theme v1.2.7
 "
 " https://github.com/zenorocha/dracula-theme
@@ -9,203 +10,463 @@
 "
 " @author Trevor Heins <@heinst>
 " @author Éverton Ribeiro <nuxlli@gmail.com>
+" @author Derek Sifford <dereksifford@gmail.com>
 " @author Zeno Rocha <hi@zenorocha.com>
+scriptencoding utf-8
+
+" Section: Initialization {{{
+
+if v:version > 580
+    highlight clear
+    if exists('syntax_on')
+        syntax reset
+    endif
+endif
+
+let g:colors_name = 'dracula'
+
+if !(has('termguicolors') && &termguicolors) && !has('gui_running') && &t_Co != 256
+    finish
+endif
+
+" }}}
+
+" Section: Palette {{{
+" --------------------
+
+let s:bg = ['#282A36', 236]
+let s:fg = ['#F8F8F2', 255]
+let s:selection = ['#44475A', 239]
+let s:comment = ['#6272A4', 61]
+let s:cyan = ['#8BE9FD', 117]
+let s:green = ['#50FA7B', 84]
+let s:orange = ['#FFB86C', 215]
+let s:pink = ['#FF79C6', 212]
+let s:purple = ['#BD93F9', 141]
+let s:red = ['#FF5555', 203]
+let s:yellow = ['#F1FA8C', 228]
+let s:none = ['NONE', 'NONE']
+
+" }}}
+
+function! s:h(scope, fg, ...)
+    " bg, attr_list, special
+    let l:bg = get(a:, 1, copy(s:none))
+    let l:attrs = a:0 >= 2 && len(a:2) > 0 ? join(a:2, ',') : 'NONE'
+    let l:special = get(a:, 3, copy(s:none))
+
+    let l:hl_string = [
+        \ 'highlight', a:scope,
+        \ 'guifg=' . a:fg[0], 'ctermfg=' . a:fg[1],
+        \ 'guibg=' . l:bg[0], 'ctermbg=' . l:bg[1],
+        \ 'gui=' . l:attrs, 'cterm=' . l:attrs,
+        \ 'guisp=' . l:special[0],
+        \]
+    execute join(l:hl_string, ' ')
+endfunction
 
 set background=dark
-highlight clear
 
-if exists("syntax_on")
-  syntax reset
-endif
+" Section: Dracula Highlight Groups {{{
 
-let g:colors_name = "dracula"
+" FIXME: Add override for this for various terminals
+highlight Normal guibg=#282A36 guifg=#F8F8F2 ctermfg=NONE ctermbg=NONE
 
-hi Cursor ctermfg=17 ctermbg=231 cterm=NONE guifg=#282a36 guibg=#f8f8f0 gui=NONE
-hi Visual ctermfg=NONE ctermbg=241 cterm=NONE guifg=NONE guibg=#44475a gui=NONE
-hi CursorLine ctermbg=234 cterm=NONE guifg=NONE guibg=#44475a gui=NONE
-hi CursorColumn ctermbg=234 cterm=NONE guifg=NONE guibg=#44475a gui=NONE
-hi ColorColumn ctermfg=NONE ctermbg=236 cterm=NONE guifg=NONE guibg=#3d3f49 gui=NONE
-hi LineNr ctermfg=60 ctermbg=NONE cterm=NONE guifg=#6272a4 guibg=#282a36 gui=NONE
-hi CursorLineNr ctermfg=228 ctermbg=234 cterm=NONE guifg=#f1fa8c guibg=#44475a gui=NONE
-hi VertSplit ctermfg=231 ctermbg=236 cterm=bold guifg=#64666d guibg=#64666d gui=bold
-hi MatchParen ctermfg=212 ctermbg=NONE cterm=underline guifg=#ff79c6 guibg=NONE gui=underline
-hi StatusLine ctermfg=231 ctermbg=236 cterm=bold guifg=#f8f8f2 guibg=#64666d gui=bold
-hi StatusLineNC ctermfg=231 ctermbg=236 cterm=NONE guifg=#f8f8f2 guibg=#64666d gui=NONE
-hi Pmenu ctermfg=15 ctermbg=61 cterm=NONE guifg=#f8f8f2 guibg=#646e96 gui=NONE
-hi PmenuSel ctermfg=16 ctermbg=84 cterm=bold guifg=#282a36 guibg=#50fa7b gui=NONE
-hi IncSearch ctermfg=17 ctermbg=215 cterm=none guifg=#282a36 guibg=#ffb86c gui=none
-hi Search ctermfg=17 ctermbg=84 cterm=none guifg=#282a36 guibg=#50fa7b gui=none
-hi Directory ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-hi Folded ctermfg=61 ctermbg=235 cterm=NONE guifg=#6272a4 guibg=#282a36 gui=NONE
-hi SignColumn ctermfg=246 ctermbg=235 cterm=NONE guifg=#909194 guibg=#44475a gui=NONE
-hi FoldColumn ctermfg=246 ctermbg=235 cterm=NONE guifg=#909194 guibg=#44475a gui=NONE
-hi Normal guifg=#f8f8f2 guibg=#282a36 gui=NONE
-hi Boolean ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-hi Character ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-hi Comment ctermfg=61 ctermbg=NONE cterm=NONE guifg=#6272a4 guibg=NONE gui=NONE
-hi Conditional ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-hi Constant ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-hi Define ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-hi DiffAdd ctermfg=231 ctermbg=64 cterm=bold guifg=#f8f8f2 guibg=#468410 gui=bold
-hi DiffDelete ctermfg=88 ctermbg=NONE cterm=NONE guifg=#8b080b guibg=NONE gui=NONE
-hi DiffChange ctermfg=231 ctermbg=23 cterm=NONE guifg=#f8f8f2 guibg=#243a5f gui=NONE
-hi DiffText ctermfg=231 ctermbg=24 cterm=bold guifg=#f8f8f2 guibg=#204a87 gui=bold
-hi ErrorMsg ctermfg=231 ctermbg=212 cterm=NONE guifg=#f8f8f0 guibg=#ff79c6 gui=NONE
-hi WarningMsg ctermfg=231 ctermbg=212 cterm=NONE guifg=#f8f8f0 guibg=#ff79c6 gui=NONE
-hi Float ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-hi Function ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-hi Identifier ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
-hi Keyword ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-hi Label ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-hi NonText ctermfg=231 ctermbg=NONE cterm=NONE guifg=#525563 guibg=NONE gui=NONE
-hi Number ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-hi Operator ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-hi PreProc ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-hi Special ctermfg=231 ctermbg=NONE cterm=NONE guifg=#f8f8f2 guibg=NONE gui=NONE
-hi SpecialComment ctermfg=61 ctermbg=NONE cterm=NONE guifg=#6272a4 guibg=NONE gui=NONE
-hi SpecialKey ctermfg=231 ctermbg=235 cterm=NONE guifg=#525563 guibg=NONE gui=NONE
-hi Statement ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-hi StorageClass ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
-hi String ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-hi SpellBad ctermfg=red ctermbg=NONE cterm=underline
-hi Tag ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-hi Title ctermfg=231 ctermbg=NONE cterm=bold guifg=#f8f8f2 guibg=NONE gui=bold
-hi Todo ctermfg=61 ctermbg=NONE cterm=inverse,bold guifg=#6272a4 guibg=NONE gui=inverse,bold
-hi Type ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
-hi Underlined ctermfg=NONE ctermbg=NONE cterm=underline guifg=NONE guibg=NONE gui=underline
-hi rubyClass ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-hi rubyFunction ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-hi rubyInterpolationDelimiter ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-hi rubySymbol ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-hi rubyConstant ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic
-hi rubyStringDelimiter ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-hi rubyBlockParameter ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic
-hi rubyInstanceVariable ctermfg=203 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=NONE
-hi rubyInclude ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-hi rubyGlobalVariable ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-hi rubyRegexp ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-hi rubyRegexpDelimiter ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-hi rubyEscape ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-hi rubyControl ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-hi rubyClassVariable ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-hi rubyOperator ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-hi rubyException ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-hi rubyPseudoVariable ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-hi rubyRailsUserClass ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic
-hi rubyRailsARAssociationMethod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
-hi rubyRailsARMethod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
-hi rubyRailsRenderMethod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
-hi rubyRailsMethod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
-hi erubyDelimiter ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-hi erubyComment ctermfg=61 ctermbg=NONE cterm=NONE guifg=#6272a4 guibg=NONE gui=NONE
-hi erubyRailsMethod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
-hi htmlTag ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-hi htmlEndTag ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-hi htmlTagName ctermfg=NONE ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-hi htmlArg ctermfg=NONE ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-hi htmlSpecialChar ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-hi javaScriptFunction ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
-hi javaScriptRailsFunction ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
-hi javaScriptBraces ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-hi yamlKey ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-hi yamlAnchor ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-hi yamlAlias ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-hi yamlDocumentHeader ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-hi cssURL ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic
-hi cssFunctionName ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
-hi cssColor ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-hi cssPseudoClassId ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-hi cssClassName ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-hi cssValueLength ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-hi cssCommonAttr ctermfg=81 ctermbg=NONE cterm=NONE guifg=#6be5fd guibg=NONE gui=NONE
-hi cssBraces ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-hi TabLineFill  cterm=NONE ctermbg=236 guifg=#333333 guibg=#282a36 gui=none
-hi TabLine      cterm=NONE ctermfg=7 ctermbg=240 guifg=#666666 guibg=#282a36 gui=none
-hi TabLineSel   guifg=WHITE guibg=#282a36 gui=none
+call s:h('DraculaFg', s:fg)
+call s:h('DraculaFgUnderline', s:fg, s:none, ['underline'])
 
-" Elixir {{{
-hi elixirAtom ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic"
-hi elixirModuleDeclaration ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic"
-hi elixirAlias ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic"
-hi elixirInterpolationDelimiter ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-hi elixirStringDelimiter ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-"}}}
-"
-" Vim Script {{{
-hi vimGroupName ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE
-hi vimGroup ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE
-hi vimOption ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE
-hi vimHiCtermFgBg ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE
-hi vimHiGuiFgBg ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE
-" }}}
-" Markdown: {{{
-hi markdownH1 ctermfg=141 ctermbg=NONE cterm=bold guifg=#bd93f9 guibg=NONE gui=bold"
-hi markdownH2 ctermfg=141 ctermbg=NONE cterm=bold guifg=#bd93f9 guibg=NONE gui=bold"
-hi markdownH3 ctermfg=212 ctermbg=NONE cterm=bold guifg=#ff79c6 guibg=NONE gui=bold"
-hi markdownH4 ctermfg=212 ctermbg=NONE cterm=bold guifg=#ff79c6 guibg=NONE gui=bold"
-hi markdownH5 ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-hi markdownH6 ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 
-hi markdownCode ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-hi markdownCodeBlock ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-hi markdownCodeDelimiter ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
+call s:h('DraculaComment', s:comment)
+call s:h('DraculaCommentBold', s:comment, s:none, ['bold'])
+call s:h('DraculaSelection', s:selection)
 
-hi markdownBlockquote ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-hi markdownListMarker ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-hi markdownOrderedListMarker ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-hi markdownRule ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-hi markdownHeadingRule ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
+call s:h('DraculaCyan', s:cyan)
+call s:h('DraculaCyanItalic', s:cyan, s:none, ['italic'])
+call s:h('DraculaGreen', s:green)
+call s:h('DraculaOrange', s:orange)
+call s:h('DraculaPink', s:pink)
+call s:h('DraculaPurple', s:purple)
+call s:h('DraculaPurple', s:purple)
+call s:h('DraculaRed', s:red)
+call s:h('DraculaYellow', s:yellow)
 
-hi markdownUrlDelimiter ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic"
-hi markdownLinkDelimiter ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic"
-hi markdownLinkTextDelimiter ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic"
+" TODO: should this also be inverted?
+call s:h('DraculaError', s:red, s:none, ['undercurl'])
+call s:h('DraculaTodo', s:green, s:none, ['bold', 'inverse'])
 
-hi markdownHeadingDelimiter ctermfg=117 ctermbg=NONE cterm=bold guifg=#8be9fd guibg=NONE gui=bold"
-hi markdownUrl ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-hi markdownUrlTitleDelimiter ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-" }}}
-" OCaml {{{
-hi ocamlModule ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
-hi ocamlConstructor ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
-hi ocamlType ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-hi ocamlModPath ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-hi ocamlTodo ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic
-hi ocamlLabel ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-hi ocamlFullMod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
-hi ocamlWith ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
-hi ocamlUnit ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 " }}}
 
-" Neovim Terminal Colors {{{
-if has("nvim")
-  let g:terminal_color_0 = "#000000"
-  let g:terminal_color_1 = "#FF5555"
-  let g:terminal_color_2 = "#50FA7B"
-  let g:terminal_color_3 = "#F1FA8C"
-  let g:terminal_color_4 = "#BD93F9"
-  let g:terminal_color_5 = "#FF79C6"
-  let g:terminal_color_6 = "#8BE9FD"
-  let g:terminal_color_7 = "#BFBFBF"
-  let g:terminal_color_8 = "#4D4D4D"
-  let g:terminal_color_9 = "#FF6E67"
-  let g:terminal_color_10 = "#5AF78E"
-  let g:terminal_color_11 = "#F4F99D"
-  let g:terminal_color_12 = "#CAA9FA"
-  let g:terminal_color_13 = "#FF92D0"
-  let g:terminal_color_14 = "#9AEDFE"
-  let g:terminal_color_15 = "#E6E6E6"
-endif
+" Section: UI {{{
+
+hi! link LineNr DraculaComment
+
 " }}}
 
-"
-"cygwin has an annoying behavior where it resets background to light
-"regardless of what is set above, so we force it yet again
-"
-"add these to get cygwin shell working when used to ssh into a centos6 vm
-"this requires your TERM=xterm-256color in the guest vm
-"- one way to do this is to append to /home/vagrant/.bash_profile ala:
-"      TERM=xterm-256color
-"      export $TERM
+" Section: Generic Syntax {{{
 
-execute "set background=dark"
-"-------------------
+hi! link Comment DraculaComment
+hi! link Folded DraculaCommentBold
+hi! link Underlined DraculaFgUnderline
+hi! link Error DraculaError
+hi! link Todo DraculaTodo
+
+" TODO: What is this exactly?
+" 	*Ignore		left blank, hidden  |hl-Ignore|
+
+hi! link Constant DraculaPurple
+hi! link String DraculaYellow
+hi! link Character DraculaPink
+hi! link Number Constant
+hi! link Boolean Constant
+hi! link Float Constant
+
+hi! link Identifier DraculaFg
+hi! link Function DraculaGreen
+
+hi! link Statement DraculaPink
+hi! link Conditional DraculaPink
+hi! link Repeat DraculaPink
+hi! link Label DraculaPink
+hi! link Operator DraculaPink
+hi! link Keyword DraculaPink
+hi! link Exception DraculaPink
+
+hi! link PreProc DraculaPink
+hi! link Include DraculaPink
+hi! link Define DraculaPink
+hi! link Macro DraculaPink
+hi! link PreCondit DraculaPink
+hi! link StorageClass DraculaPink
+hi! link Structure DraculaPink
+hi! link Typedef DraculaPink
+
+hi! link Type DraculaCyanItalic
+
+" TODO: need a consensus here
+" 	*Special	any special symbol
+" 	 SpecialChar	special character in a constant
+" 	 Tag		you can use CTRL-] on this
+" 	 Delimiter	character that needs attention
+" 	 SpecialComment	special things inside a comment
+" 	 Debug		debugging statements
+
+
+" }}}
+
+" TODO {{{
+
+"ColorColumn	used for the columns set with 'colorcolumn'
+"							*hl-Conceal*
+"Conceal		placeholder characters substituted for concealed
+"		text (see 'conceallevel')
+"							*hl-Cursor*
+"Cursor		the character under the cursor
+"							*hl-CursorIM*
+"CursorIM	like Cursor, but used when in IME mode |CursorIM|
+"							*hl-CursorColumn*
+"CursorColumn	the screen column that the cursor is in when 'cursorcolumn' is
+"		set
+"							*hl-CursorLine*
+"CursorLine	the screen line that the cursor is in when 'cursorline' is
+"		set
+"							*hl-Directory*
+"Directory	directory names (and other special names in listings)
+"							*hl-DiffAdd*
+"DiffAdd		diff mode: Added line |diff.txt|
+"							*hl-DiffChange*
+"DiffChange	diff mode: Changed line |diff.txt|
+"							*hl-DiffDelete*
+"DiffDelete	diff mode: Deleted line |diff.txt|
+"							*hl-DiffText*
+"DiffText	diff mode: Changed text within a changed line |diff.txt|
+"						 {Nvim} *hl-EndOfBuffer*
+"EndOfBuffer	filler lines (~) after the end of the buffer.
+"		By default, this is highlighted like |hl-NonText|.
+"						 {Nvim} *hl-TermCursor*
+"TermCursor	cursor in a focused terminal
+"						 {Nvim} *hl-TermCursorNC*
+"TermCursorNC	cursor in an unfocused terminal
+"							*hl-ErrorMsg*
+"ErrorMsg	error messages on the command line
+"							*hl-VertSplit*
+"VertSplit	the column separating vertically split windows
+"							*hl-Folded*
+"Folded		line used for closed folds
+"							*hl-FoldColumn*
+"FoldColumn	'foldcolumn'
+"							*hl-SignColumn*
+"SignColumn	column where |signs| are displayed
+"							*hl-IncSearch*
+"IncSearch	'incsearch' highlighting; also used for the text replaced with
+"		":s///c"
+"							*hl-Substitute*
+"Substitute	|:substitute| replacement text highlighting
+
+"							*hl-LineNr*
+"LineNr		Line number for ":number" and ":#" commands, and when 'number'
+"		or 'relativenumber' option is set.
+"							*hl-CursorLineNr*
+"CursorLineNr	Like LineNr when 'cursorline' or 'relativenumber' is set for
+"		the cursor line.
+"							*hl-MatchParen*
+"MatchParen	The character under the cursor or just before it, if it
+"		is a paired bracket, and its match. |pi_paren.txt|
+
+"							*hl-ModeMsg*
+"ModeMsg		'showmode' message (e.g., "-- INSERT --")
+"							*hl-MoreMsg*
+"MoreMsg		|more-prompt|
+"							*hl-NonText*
+"NonText		'@' at the end of the window, characters from 'showbreak'
+"		and other characters that do not really exist in the text
+"		(e.g., ">" displayed when a double-wide character doesn't
+"		fit at the end of the line). See also |hl-EndOfBuffer|.
+"							*hl-Normal*
+"Normal		normal text
+"							*hl-NormalNC*
+"NormalNC	normal text in non-current windows
+"							*hl-Pmenu*
+"Pmenu		Popup menu: normal item.
+"							*hl-PmenuSel*
+"PmenuSel	Popup menu: selected item.
+"							*hl-PmenuSbar*
+"PmenuSbar	Popup menu: scrollbar.
+"							*hl-PmenuThumb*
+"PmenuThumb	Popup menu: Thumb of the scrollbar.
+"							*hl-Question*
+"Question	|hit-enter| prompt and yes/no questions
+"							*hl-QuickFixLine*
+"QuickFixLine	Current |quickfix| item in the quickfix window. Combined with
+"                |hl-CursorLine| when the cursor is there.
+"							*hl-Search*
+"Search		Last search pattern highlighting (see 'hlsearch').
+"		Also used for similar items that need to stand out.
+"							*hl-SpecialKey*
+"SpecialKey	Unprintable characters: text displayed differently from what
+"		it really is. But not 'listchars' whitespace. |hl-Whitespace|
+"							*hl-SpellBad*
+"SpellBad	Word that is not recognized by the spellchecker. |spell|
+"		Combined with the highlighting used otherwise.
+"							*hl-SpellCap*
+"SpellCap	Word that should start with a capital. |spell|
+"		Combined with the highlighting used otherwise.
+"							*hl-SpellLocal*
+"SpellLocal	Word that is recognized by the spellchecker as one that is
+"		used in another region. |spell|
+"		Combined with the highlighting used otherwise.
+"							*hl-SpellRare*
+"SpellRare	Word that is recognized by the spellchecker as one that is
+"		hardly ever used. |spell|
+"		Combined with the highlighting used otherwise.
+"							*hl-StatusLine*
+"StatusLine	status line of current window
+"							*hl-StatusLineNC*
+"StatusLineNC	status lines of not-current windows
+"		Note: if this is equal to "StatusLine" Vim will use "^^^" in
+"		the status line of the current window.
+"							*hl-TabLine*
+"TabLine		tab pages line, not active tab page label
+"							*hl-TabLineFill*
+"TabLineFill	tab pages line, where there are no labels
+"							*hl-TabLineSel*
+"TabLineSel	tab pages line, active tab page label
+"							*hl-Title*
+"Title		titles for output from ":set all", ":autocmd" etc.
+"							*hl-Visual*
+"Visual		Visual mode selection
+" 							*hl-VisualNOS*
+"VisualNOS	Visual mode selection when vim is "Not Owning the Selection".
+"							*hl-WarningMsg*
+"WarningMsg	warning messages
+"							*hl-Whitespace*
+"Whitespace	"nbsp", "space", "tab" and "trail" in 'listchars'
+"							*hl-WildMenu*
+"WildMenu	current match in 'wildmenu' completion
+
+" }}}
+
+" FIXME: Old stuff {{{
+
+"hi Cursor ctermfg=17 ctermbg=231 cterm=NONE guifg=#282a36 guibg=#f8f8f0 gui=NONE
+"hi Visual ctermfg=NONE ctermbg=241 cterm=NONE guifg=NONE guibg=#44475a gui=NONE
+"hi CursorLine ctermbg=234 cterm=NONE guifg=NONE guibg=#44475a gui=NONE
+"hi CursorColumn ctermbg=234 cterm=NONE guifg=NONE guibg=#44475a gui=NONE
+"hi ColorColumn ctermfg=NONE ctermbg=236 cterm=NONE guifg=NONE guibg=#3d3f49 gui=NONE
+"hi LineNr ctermfg=60 ctermbg=NONE cterm=NONE guifg=#6272a4 guibg=#282a36 gui=NONE
+"hi CursorLineNr ctermfg=228 ctermbg=234 cterm=NONE guifg=#f1fa8c guibg=#44475a gui=NONE
+"hi VertSplit ctermfg=231 ctermbg=236 cterm=bold guifg=#64666d guibg=#64666d gui=bold
+"hi MatchParen ctermfg=212 ctermbg=NONE cterm=underline guifg=#ff79c6 guibg=NONE gui=underline
+"hi StatusLine ctermfg=231 ctermbg=236 cterm=bold guifg=#f8f8f2 guibg=#64666d gui=bold
+"hi StatusLineNC ctermfg=231 ctermbg=236 cterm=NONE guifg=#f8f8f2 guibg=#64666d gui=NONE
+"hi Pmenu ctermfg=15 ctermbg=61 cterm=NONE guifg=#f8f8f2 guibg=#646e96 gui=NONE
+"hi PmenuSel ctermfg=16 ctermbg=84 cterm=bold guifg=#282a36 guibg=#50fa7b gui=NONE
+"hi IncSearch ctermfg=17 ctermbg=215 cterm=none guifg=#282a36 guibg=#ffb86c gui=none
+"hi Search ctermfg=17 ctermbg=84 cterm=none guifg=#282a36 guibg=#50fa7b gui=none
+"hi Directory ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
+"hi Folded ctermfg=61 ctermbg=235 cterm=NONE guifg=#6272a4 guibg=#282a36 gui=NONE
+"hi SignColumn ctermfg=246 ctermbg=235 cterm=NONE guifg=#909194 guibg=#44475a gui=NONE
+"hi FoldColumn ctermfg=246 ctermbg=235 cterm=NONE guifg=#909194 guibg=#44475a gui=NONE
+"hi Normal guifg=#f8f8f2 guibg=#282a36 gui=NONE
+"hi Boolean ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
+"hi Character ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
+"hi Comment ctermfg=61 ctermbg=NONE cterm=NONE guifg=#6272a4 guibg=NONE gui=NONE
+"hi Conditional ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+"hi Constant ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+"hi Define ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+"hi DiffAdd ctermfg=231 ctermbg=64 cterm=bold guifg=#f8f8f2 guibg=#468410 gui=bold
+"hi DiffDelete ctermfg=88 ctermbg=NONE cterm=NONE guifg=#8b080b guibg=NONE gui=NONE
+"hi DiffChange ctermfg=231 ctermbg=23 cterm=NONE guifg=#f8f8f2 guibg=#243a5f gui=NONE
+"hi DiffText ctermfg=231 ctermbg=24 cterm=bold guifg=#f8f8f2 guibg=#204a87 gui=bold
+"hi ErrorMsg ctermfg=231 ctermbg=212 cterm=NONE guifg=#f8f8f0 guibg=#ff79c6 gui=NONE
+"hi WarningMsg ctermfg=231 ctermbg=212 cterm=NONE guifg=#f8f8f0 guibg=#ff79c6 gui=NONE
+"hi Float ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
+"hi Function ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
+"hi Identifier ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
+"hi Keyword ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+"hi Label ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
+"hi NonText ctermfg=231 ctermbg=NONE cterm=NONE guifg=#525563 guibg=NONE gui=NONE
+"hi Number ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
+"hi Operator ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+"hi PreProc ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+"hi Special ctermfg=231 ctermbg=NONE cterm=NONE guifg=#f8f8f2 guibg=NONE gui=NONE
+"hi SpecialComment ctermfg=61 ctermbg=NONE cterm=NONE guifg=#6272a4 guibg=NONE gui=NONE
+"hi SpecialKey ctermfg=231 ctermbg=235 cterm=NONE guifg=#525563 guibg=NONE gui=NONE
+"hi Statement ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+"hi StorageClass ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
+"hi String ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
+"hi SpellBad ctermfg=red ctermbg=NONE cterm=underline
+"hi Tag ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+"hi Title ctermfg=231 ctermbg=NONE cterm=bold guifg=#f8f8f2 guibg=NONE gui=bold
+"hi Todo ctermfg=61 ctermbg=NONE cterm=inverse,bold guifg=#6272a4 guibg=NONE gui=inverse,bold
+"hi Type ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
+"hi Underlined ctermfg=NONE ctermbg=NONE cterm=underline guifg=NONE guibg=NONE gui=underline
+"hi rubyClass ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+"hi rubyFunction ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
+"hi rubyInterpolationDelimiter ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+"hi rubySymbol ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
+"hi rubyConstant ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic
+"hi rubyStringDelimiter ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
+"hi rubyBlockParameter ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic
+"hi rubyInstanceVariable ctermfg=203 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=NONE
+"hi rubyInclude ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+"hi rubyGlobalVariable ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+"hi rubyRegexp ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
+"hi rubyRegexpDelimiter ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
+"hi rubyEscape ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
+"hi rubyControl ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+"hi rubyClassVariable ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+"hi rubyOperator ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+"hi rubyException ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+"hi rubyPseudoVariable ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+"hi rubyRailsUserClass ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic
+"hi rubyRailsARAssociationMethod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
+"hi rubyRailsARMethod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
+"hi rubyRailsRenderMethod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
+"hi rubyRailsMethod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
+"hi erubyDelimiter ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+"hi erubyComment ctermfg=61 ctermbg=NONE cterm=NONE guifg=#6272a4 guibg=NONE gui=NONE
+"hi erubyRailsMethod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
+"hi htmlTag ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+"hi htmlEndTag ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+"hi htmlTagName ctermfg=NONE ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+"hi htmlArg ctermfg=NONE ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
+"hi htmlSpecialChar ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
+"hi javaScriptFunction ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
+"hi javaScriptRailsFunction ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
+"hi javaScriptBraces ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+"hi yamlKey ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+"hi yamlAnchor ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+"hi yamlAlias ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+"hi yamlDocumentHeader ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
+"hi cssURL ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic
+"hi cssFunctionName ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
+"hi cssColor ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
+"hi cssPseudoClassId ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
+"hi cssClassName ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
+"hi cssValueLength ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
+"hi cssCommonAttr ctermfg=81 ctermbg=NONE cterm=NONE guifg=#6be5fd guibg=NONE gui=NONE
+"hi cssBraces ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+"hi TabLineFill  cterm=NONE ctermbg=236 guifg=#333333 guibg=#282a36 gui=none
+"hi TabLine      cterm=NONE ctermfg=7 ctermbg=240 guifg=#666666 guibg=#282a36 gui=none
+"hi TabLineSel   guifg=WHITE guibg=#282a36 gui=none
+
+"" Elixir {{{
+"hi elixirAtom ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic"
+"hi elixirModuleDeclaration ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic"
+"hi elixirAlias ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic"
+"hi elixirInterpolationDelimiter ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
+"hi elixirStringDelimiter ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
+""}}}
+""
+"" Vim Script {{{
+"hi vimGroupName ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE
+"hi vimGroup ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE
+"hi vimOption ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE
+"hi vimHiCtermFgBg ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE
+"hi vimHiGuiFgBg ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE
+"" }}}
+"" Markdown: {{{
+"hi markdownH1 ctermfg=141 ctermbg=NONE cterm=bold guifg=#bd93f9 guibg=NONE gui=bold"
+"hi markdownH2 ctermfg=141 ctermbg=NONE cterm=bold guifg=#bd93f9 guibg=NONE gui=bold"
+"hi markdownH3 ctermfg=212 ctermbg=NONE cterm=bold guifg=#ff79c6 guibg=NONE gui=bold"
+"hi markdownH4 ctermfg=212 ctermbg=NONE cterm=bold guifg=#ff79c6 guibg=NONE gui=bold"
+"hi markdownH5 ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+"hi markdownH6 ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+
+"hi markdownCode ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
+"hi markdownCodeBlock ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
+"hi markdownCodeDelimiter ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
+
+"hi markdownBlockquote ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
+"hi markdownListMarker ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
+"hi markdownOrderedListMarker ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
+"hi markdownRule ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
+"hi markdownHeadingRule ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
+
+"hi markdownUrlDelimiter ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic"
+"hi markdownLinkDelimiter ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic"
+"hi markdownLinkTextDelimiter ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic"
+
+"hi markdownHeadingDelimiter ctermfg=117 ctermbg=NONE cterm=bold guifg=#8be9fd guibg=NONE gui=bold"
+"hi markdownUrl ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
+"hi markdownUrlTitleDelimiter ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
+"" }}}
+"" OCaml {{{
+"hi ocamlModule ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
+"hi ocamlConstructor ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
+"hi ocamlType ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
+"hi ocamlModPath ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
+"hi ocamlTodo ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic
+"hi ocamlLabel ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
+"hi ocamlFullMod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
+"hi ocamlWith ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
+"hi ocamlUnit ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
+"" }}}
+
+"" Neovim Terminal Colors {{{
+"if has("nvim")
+"  let g:terminal_color_0 = "#000000"
+"  let g:terminal_color_1 = "#FF5555"
+"  let g:terminal_color_2 = "#50FA7B"
+"  let g:terminal_color_3 = "#F1FA8C"
+"  let g:terminal_color_4 = "#BD93F9"
+"  let g:terminal_color_5 = "#FF79C6"
+"  let g:terminal_color_6 = "#8BE9FD"
+"  let g:terminal_color_7 = "#BFBFBF"
+"  let g:terminal_color_8 = "#4D4D4D"
+"  let g:terminal_color_9 = "#FF6E67"
+"  let g:terminal_color_10 = "#5AF78E"
+"  let g:terminal_color_11 = "#F4F99D"
+"  let g:terminal_color_12 = "#CAA9FA"
+"  let g:terminal_color_13 = "#FF92D0"
+"  let g:terminal_color_14 = "#9AEDFE"
+"  let g:terminal_color_15 = "#E6E6E6"
+"endif
+"" }}}
+
+" TODO: Verify this
+" Must be at EOF. See: https://groups.google.com/forum/#!msg/vim_dev/afPqwAFNdrU/nqh6tOM87QUJ
+" set background=dark
+
+" }}}
+

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -110,8 +110,8 @@ function! s:h(scope, fg, ...) " bg, attr_list, special
   let l:fg = copy(a:fg)
   let l:bg = get(a:, 1, ['NONE', 'NONE'])
 
-  let l:attr_list = filter(get(a:, 2, ['NONE']), {idx, val -> val != 0})
-  let l:attrs = len(l:attr_list) > 0 ? join(l:attr_list, ' ') : 'NONE'
+  let l:attr_list = filter(get(a:, 2, ['NONE']), {idx, val -> type(val) == 1})
+  let l:attrs = len(l:attr_list) > 0 ? join(l:attr_list, ',') : 'NONE'
 
   " Falls back to coloring foreground group on terminals because
   " nearly all do not support undercurl

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -333,6 +333,21 @@ hi! link cssProp DraculaCyan
 hi! link cssPseudoClassId DraculaGreenItalic
 
 "}}}2
+" Git Commit: {{{2
+
+" These groups appear when editing commit messages.
+" They are not part of the Diff interface of vim diff
+
+" The following two are misnomers. Colors are correct.
+hi! link diffFile DraculaGreen
+hi! link diffNewFile DraculaRed
+
+hi! link diffLine DraculaPurpleBold
+hi! link diffLine DraculaCyanItalic
+hi! link diffRemoved DraculaRed
+hi! link diffAdded DraculaGreen
+
+"}}}2
 " HTML: {{{2
 
 hi! link htmlTag DraculaFg

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -29,30 +29,29 @@ if !(has('termguicolors') && &termguicolors) && !has('gui_running') && &t_Co != 
   finish
 endif
 
-
 " Palette: {{{2
 
-let s:fg        = ['#F8F8F2', 255]
+let s:fg        = ['#F8F8F2', 255] | lockvar s:fg
 
-let s:bglighter = ['#424450', 238]
-let s:bglight   = ['#343746', 237]
-let s:bg        = ['#282A36', 236]
-let s:bgdark    = ['#21222C', 235]
-let s:bgdarker  = ['#191A21', 234]
+let s:bglighter = ['#424450', 238] | lockvar s:bglighter
+let s:bglight   = ['#343746', 237] | lockvar s:bglight
+let s:bg        = ['#282A36', 236] | lockvar s:bg
+let s:bgdark    = ['#21222C', 235] | lockvar s:bgdark
+let s:bgdarker  = ['#191A21', 234] | lockvar s:bgdarker
 
-let s:subtle    = ['#424450', 238]
+let s:subtle    = ['#424450', 238] | lockvar s:subtle
 
-let s:selection = ['#44475A', 239]
-let s:comment   = ['#6272A4',  61]
-let s:cyan      = ['#8BE9FD', 117]
-let s:green     = ['#50FA7B',  84]
-let s:orange    = ['#FFB86C', 215]
-let s:pink      = ['#FF79C6', 212]
-let s:purple    = ['#BD93F9', 141]
-let s:red       = ['#FF5555', 203]
-let s:yellow    = ['#F1FA8C', 228]
+let s:selection = ['#44475A', 239] | lockvar s:selection
+let s:comment   = ['#6272A4',  61] | lockvar s:comment
+let s:cyan      = ['#8BE9FD', 117] | lockvar s:cyan
+let s:green     = ['#50FA7B',  84] | lockvar s:green
+let s:orange    = ['#FFB86C', 215] | lockvar s:orange
+let s:pink      = ['#FF79C6', 212] | lockvar s:pink
+let s:purple    = ['#BD93F9', 141] | lockvar s:purple
+let s:red       = ['#FF5555', 203] | lockvar s:red
+let s:yellow    = ['#F1FA8C', 228] | lockvar s:yellow
 
-let s:none      = ['NONE', 'NONE']
+let s:none      = ['NONE', 'NONE'] | lockvar s:none
 
 if has('nvim')
   let g:terminal_color_0  = '#44475A'
@@ -74,23 +73,65 @@ if has('nvim')
 endif
 
 " }}}2
+" User Configuration: {{{2
 
-function! s:h(scope, fg, ...)
-  " bg, attr_list, special
-  let l:bg = get(a:, 1, copy(s:none))
-  let l:attrs = a:0 >= 2 && len(a:2) > 0 ? join(a:2, ',') : 'NONE'
-  let l:special = get(a:, 3, copy(s:none))
+if !exists('g:dracula_bold')
+  let g:dracula_bold = 1
+endif
+
+if !exists('g:dracula_italic')
+  let g:dracula_italic = 1
+endif
+
+if !exists('g:dracula_underline')
+  let g:dracula_underline = 1
+endif
+
+if !exists('g:dracula_undercurl') && g:dracula_underline != 0
+  let g:dracula_undercurl = 1
+endif
+
+if !exists('g:dracula_inverse')
+  let g:dracula_inverse = 1
+endif
+
+"}}}2
+" Script Helpers: {{{2
+
+let s:attrs = {
+      \ 'bold': g:dracula_bold == 1 ? 'bold' : 0,
+      \ 'italic': g:dracula_italic == 1 ? 'italic' : 0,
+      \ 'underline': g:dracula_underline == 1 ? 'underline' : 0,
+      \ 'undercurl': g:dracula_undercurl == 1 ? 'undercurl' : 0,
+      \ 'inverse': g:dracula_inverse == 1 ? 'inverse' : 0,
+      \} | lockvar s:attrs
+
+function! s:h(scope, fg, ...) " bg, attr_list, special
+  let l:fg = copy(a:fg)
+  let l:bg = get(a:, 1, ['NONE', 'NONE'])
+
+  let l:attr_list = join(get(a:, 2, ['NONE']), ',')
+
+  " Falls back to coloring foreground group on terminals because
+  " nearly all do not support undercurl
+  let l:special = get(a:, 3, ['NONE', 'NONE'])
+  if l:special[0] !=# 'NONE' && l:fg[0] ==# 'NONE' && !has('gui_running')
+    let l:fg[0] = l:special[0]
+    let l:fg[1] = l:special[1]
+  endif
 
   let l:hl_string = [
         \ 'highlight', a:scope,
-        \ 'guifg=' . a:fg[0], 'ctermfg=' . a:fg[1],
+        \ 'guifg=' . l:fg[0], 'ctermfg=' . l:fg[1],
         \ 'guibg=' . l:bg[0], 'ctermbg=' . l:bg[1],
-        \ 'gui=' . l:attrs, 'cterm=' . l:attrs,
+        \ 'gui=' . l:attr_list, 'cterm=' . l:attr_list,
         \ 'guisp=' . l:special[0],
         \]
+
   execute join(l:hl_string, ' ')
 endfunction
 
+"}}}2
 " Dracula Highlight Groups: {{{2
 
 call s:h('DraculaBgLight', s:none, s:bglight)
@@ -99,54 +140,54 @@ call s:h('DraculaBgDark', s:none, s:bgdark)
 call s:h('DraculaBgDarker', s:none, s:bgdarker)
 
 call s:h('DraculaFg', s:fg)
-call s:h('DraculaFgUnderline', s:fg, s:none, ['underline'])
-call s:h('DraculaFgBold', s:fg, s:none, ['bold'])
+call s:h('DraculaFgUnderline', s:fg, s:none, [s:attrs.underline])
+call s:h('DraculaFgBold', s:fg, s:none, [s:attrs.bold])
 
 call s:h('DraculaComment', s:comment)
-call s:h('DraculaCommentBold', s:comment, s:none, ['bold'])
+call s:h('DraculaCommentBold', s:comment, s:none, [s:attrs.bold])
 
 call s:h('DraculaSelection', s:none, s:selection)
 
 call s:h('DraculaSubtle', s:subtle)
 
 call s:h('DraculaCyan', s:cyan)
-call s:h('DraculaCyanItalic', s:cyan, s:none, ['italic'])
+call s:h('DraculaCyanItalic', s:cyan, s:none, [s:attrs.italic])
 
 call s:h('DraculaGreen', s:green)
-call s:h('DraculaGreenBold', s:green, s:none, ['bold'])
-call s:h('DraculaGreenItalic', s:green, s:none, ['italic'])
-call s:h('DraculaGreenItalicUnderline', s:green, s:none, ['italic', 'underline'])
+call s:h('DraculaGreenBold', s:green, s:none, [s:attrs.bold])
+call s:h('DraculaGreenItalic', s:green, s:none, [s:attrs.italic])
+call s:h('DraculaGreenItalicUnderline', s:green, s:none, [s:attrs.italic, s:attrs.underline])
 
 call s:h('DraculaOrange', s:orange)
-call s:h('DraculaOrangeBold', s:orange, s:none, ['bold'])
-call s:h('DraculaOrangeItalic', s:orange, s:none, ['italic'])
-call s:h('DraculaOrangeBoldItalic', s:orange, s:none, ['bold', 'italic'])
+call s:h('DraculaOrangeBold', s:orange, s:none, [s:attrs.bold])
+call s:h('DraculaOrangeItalic', s:orange, s:none, [s:attrs.italic])
+call s:h('DraculaOrangeBoldItalic', s:orange, s:none, [s:attrs.bold, s:attrs.italic])
 call s:h('DraculaOrangeInverse', s:bg, s:orange)
 
 call s:h('DraculaPink', s:pink)
-call s:h('DraculaPinkItalic', s:pink, s:none, ['italic'])
+call s:h('DraculaPinkItalic', s:pink, s:none, [s:attrs.italic])
 
 call s:h('DraculaPurple', s:purple)
-call s:h('DraculaPurpleBold', s:purple, s:none, ['bold'])
-call s:h('DraculaPurpleItalic', s:purple, s:none, ['italic'])
+call s:h('DraculaPurpleBold', s:purple, s:none, [s:attrs.bold])
+call s:h('DraculaPurpleItalic', s:purple, s:none, [s:attrs.italic])
 
 call s:h('DraculaRed', s:red)
 call s:h('DraculaRedInverse', s:fg, s:red)
 
 call s:h('DraculaYellow', s:yellow)
-call s:h('DraculaYellowItalic', s:yellow, s:none, ['italic'])
+call s:h('DraculaYellowItalic', s:yellow, s:none, [s:attrs.italic])
 
-call s:h('DraculaError', s:red, s:none, ['undercurl'], s:red)
-call s:h('DraculaWarn', s:orange, s:none, ['undercurl'], s:orange)
+call s:h('DraculaError', s:red, s:none, [s:attrs.undercurl], s:red)
+call s:h('DraculaWarn', s:orange, s:none, [s:attrs.undercurl], s:orange)
 
-call s:h('DraculaErrorLine', s:none, s:none, ['undercurl'], s:red)
-call s:h('DraculaWarnLine', s:none, s:none, ['undercurl'], s:orange)
-call s:h('DraculaInfoLine', s:none, s:none, ['undercurl'], s:cyan)
+call s:h('DraculaErrorLine', s:none, s:none, [s:attrs.undercurl], s:red)
+call s:h('DraculaWarnLine', s:none, s:none, [s:attrs.undercurl], s:orange)
+call s:h('DraculaInfoLine', s:none, s:none, [s:attrs.undercurl], s:cyan)
 
-call s:h('DraculaTodo', s:cyan, s:none, ['bold', 'inverse'])
-call s:h('DraculaSearch', s:green, s:none, ['inverse'])
+call s:h('DraculaTodo', s:cyan, s:none, [s:attrs.bold, s:attrs.inverse])
+call s:h('DraculaSearch', s:green, s:none, [s:attrs.inverse])
 call s:h('DraculaBoundary', s:comment, s:bgdark)
-call s:h('DraculaLink', s:cyan, s:none, ['underline'])
+call s:h('DraculaLink', s:cyan, s:none, [s:attrs.underline])
 
 call s:h('DraculaDiffChange', s:none, s:none)
 call s:h('DraculaDiffText', s:bg, s:orange)
@@ -167,9 +208,9 @@ hi! link Search DraculaSearch
 hi! link IncSearch DraculaOrangeInverse
 
 " Status / Command Line
-call s:h('StatusLine', s:none, s:bglighter, ['bold'])
+call s:h('StatusLine', s:none, s:bglighter, [s:attrs.bold])
 call s:h('StatusLineNC', s:none, s:bglight)
-call s:h('WildMenu', s:bg, s:purple, ['bold'])
+call s:h('WildMenu', s:bg, s:purple, [s:attrs.bold])
 
 " Tabs
 call s:h('TabLine', s:comment, s:bgdark)
@@ -275,7 +316,7 @@ hi! link helpHyperTextJump DraculaLink
 hi! link helpCommand DraculaPurple
 hi! link helpExample DraculaGreen
 
-call s:h('MatchParen', s:none, s:pink, ['underline'])
+call s:h('MatchParen', s:none, s:pink, [s:attrs.underline])
 call s:h('Conceal', s:comment, s:bglight)
 
 " CSS: {{{2

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -342,7 +342,6 @@ hi! link cssPseudoClassId DraculaGreenItalic
 hi! link diffFile DraculaGreen
 hi! link diffNewFile DraculaRed
 
-hi! link diffLine DraculaPurpleBold
 hi! link diffLine DraculaCyanItalic
 hi! link diffRemoved DraculaRed
 hi! link diffAdded DraculaGreen

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -213,7 +213,7 @@ call s:h('StatusLineNC', s:none, s:bglight)
 call s:h('WildMenu', s:bg, s:purple, [s:attrs.bold])
 
 " Tabs
-call s:h('TabLine', s:comment, s:bgdark)
+hi! link TabLine DraculaBoundary
 hi! link TabLineFill DraculaBgDarker
 hi! link TabLineSel Normal
 
@@ -240,8 +240,8 @@ hi! link CursorLineNr DraculaYellow
 hi! link LineNr DraculaComment
 
 " Whitespace / Non-text
+call s:h('CursorLine', s:none, s:subtle) " Required as some plugins will overwrite
 hi! link NonText DraculaSubtle
-hi! link CursorLine DraculaSelection
 hi! link CursorColumn DraculaSelection
 hi! link ColorColumn DraculaSelection
 

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -110,7 +110,8 @@ function! s:h(scope, fg, ...) " bg, attr_list, special
   let l:fg = copy(a:fg)
   let l:bg = get(a:, 1, ['NONE', 'NONE'])
 
-  let l:attr_list = join(get(a:, 2, ['NONE']), ',')
+  let l:attr_list = filter(get(a:, 2, ['NONE']), {idx, val -> val != 0})
+  let l:attrs = len(l:attr_list) > 0 ? join(l:attr_list, ' ') : 'NONE'
 
   " Falls back to coloring foreground group on terminals because
   " nearly all do not support undercurl
@@ -124,7 +125,7 @@ function! s:h(scope, fg, ...) " bg, attr_list, special
         \ 'highlight', a:scope,
         \ 'guifg=' . l:fg[0], 'ctermfg=' . l:fg[1],
         \ 'guibg=' . l:bg[0], 'ctermbg=' . l:bg[1],
-        \ 'gui=' . l:attr_list, 'cterm=' . l:attr_list,
+        \ 'gui=' . l:attrs, 'cterm=' . l:attrs,
         \ 'guisp=' . l:special[0],
         \]
 

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -291,16 +291,6 @@ hi! link cssProp DraculaCyan
 hi! link cssPseudoClassId DraculaGreenItalic
 
 "}}}2
-" Elixir: {{{2
-
-"TODO:
-"hi elixirAtom ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic"
-"hi elixirModuleDeclaration ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic"
-"hi elixirAlias ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic"
-"hi elixirInterpolationDelimiter ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-"hi elixirStringDelimiter ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-
-"}}}2
 " HTML: {{{2
 
 hi! link htmlTag DraculaFg
@@ -312,10 +302,10 @@ hi! link htmlSpecialChar DraculaPurple
 "}}}2
 " JavaScript: {{{2
 
-"TODO:
-"hi javaScriptFunction ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
-"hi javaScriptRailsFunction ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
-"hi javaScriptBraces ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+hi! link javaScriptBraces Delimiter
+hi! link javaScriptNumber Constant
+hi! link javaScriptNull Constant
+hi! link javaScriptFunction DraculaPink
 
 "}}}2
 " Markdown: {{{2
@@ -348,20 +338,6 @@ hi! link markdownLinkText DraculaPink
 hi! link markdownUrl DraculaLink
 
 "}}}2
-" OCaml: {{{2
-
-"TODO:
-"hi ocamlModule ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
-"hi ocamlConstructor ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
-"hi ocamlType ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-"hi ocamlModPath ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-"hi ocamlTodo ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic
-"hi ocamlLabel ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-"hi ocamlFullMod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
-"hi ocamlWith ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
-"hi ocamlUnit ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-
-"}}}2
 " Ruby: {{{2
 
 let g:ruby_operators=1
@@ -388,14 +364,19 @@ hi! link yamlFlowIndicator Delimiter
 "}}}2
 " Vim Script: {{{2
 
-"TODO:
-"hi vimGroupName ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE
-"hi vimGroup ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE
-"hi vimOption ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE
-"hi vimHiCtermFgBg ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE
-"hi vimHiGuiFgBg ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE
+hi! link vimOption DraculaCyanItalic
+hi! link vimAutoEventList DraculaCyanItalic
+hi! link vimAutoCmdSfxList DraculaCyanItalic
+hi! link vimSetSep Delimiter
+hi! link vimSetMod DraculaPink
+hi! link vimHiBang DraculaPink
+hi! link vimEnvVar DraculaPurple
+hi! link vimUserFunc DraculaGreen
+hi! link vimFunction DraculaGreen
+hi! link vimUserAttrbCmpltFunc DraculaGreen
 
 "}}}2
+
 "}}}
 
 " vim: fdm=marker ts=2 sts=2 sw=2:

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -1,5 +1,4 @@
-" vim: fdm=marker:
-" Dracula Theme v1.2.7
+" Dracula Theme: v1.2.7 {{{
 "
 " https://github.com/zenorocha/dracula-theme
 "
@@ -12,106 +11,230 @@
 " @author Éverton Ribeiro <nuxlli@gmail.com>
 " @author Derek Sifford <dereksifford@gmail.com>
 " @author Zeno Rocha <hi@zenorocha.com>
-scriptencoding utf-8
+scriptencoding utf8
+" }}}
 
-" Section: Initialization {{{
+" Configuration: {{{
 
 if v:version > 580
-    highlight clear
-    if exists('syntax_on')
-        syntax reset
-    endif
+  highlight clear
+  if exists('syntax_on')
+    syntax reset
+  endif
 endif
 
 let g:colors_name = 'dracula'
 
 if !(has('termguicolors') && &termguicolors) && !has('gui_running') && &t_Co != 256
-    finish
+  finish
 endif
 
-" }}}
 
-" Section: Palette {{{
-" --------------------
+" Palette: {{{2
 
-let s:bg = ['#282A36', 236]
-let s:fg = ['#F8F8F2', 255]
+let s:fg        = ['#F8F8F2', 255]
+
+let s:bglighter = ['#424450', 238]
+let s:bglight   = ['#343746', 237]
+let s:bg        = ['#282A36', 236]
+let s:bgdark    = ['#21222C', 235]
+let s:bgdarker  = ['#191A21', 234]
+
+let s:subtle    = ['#424450', 238]
+
 let s:selection = ['#44475A', 239]
-let s:comment = ['#6272A4', 61]
-let s:cyan = ['#8BE9FD', 117]
-let s:green = ['#50FA7B', 84]
-let s:orange = ['#FFB86C', 215]
-let s:pink = ['#FF79C6', 212]
-let s:purple = ['#BD93F9', 141]
-let s:red = ['#FF5555', 203]
-let s:yellow = ['#F1FA8C', 228]
-let s:none = ['NONE', 'NONE']
+let s:comment   = ['#6272A4',  61]
+let s:cyan      = ['#8BE9FD', 117]
+let s:green     = ['#50FA7B',  84]
+let s:orange    = ['#FFB86C', 215]
+let s:pink      = ['#FF79C6', 212]
+let s:purple    = ['#BD93F9', 141]
+let s:red       = ['#FF5555', 203]
+let s:yellow    = ['#F1FA8C', 228]
 
-" }}}
+let s:none      = ['NONE', 'NONE']
+
+if has('nvim')
+  let g:terminal_color_0  = '#44475A'
+  let g:terminal_color_1  = '#DE312B'
+  let g:terminal_color_2  = '#2FD651'
+  let g:terminal_color_3  = '#D0D662'
+  let g:terminal_color_4  = '#9C6FCF'
+  let g:terminal_color_5  = '#DE559C'
+  let g:terminal_color_6  = '#6AC5D3'
+  let g:terminal_color_7  = '#D7D4C8'
+  let g:terminal_color_8  = '#656B84'
+  let g:terminal_color_9  = '#FF5555'
+  let g:terminal_color_10 = '#50FA7B'
+  let g:terminal_color_11 = '#F1FA8C'
+  let g:terminal_color_12 = '#BD93F9'
+  let g:terminal_color_13 = '#FF79C6'
+  let g:terminal_color_14 = '#8BE9FD'
+  let g:terminal_color_15 = '#F8F8F2'
+endif
+
+" }}}2
 
 function! s:h(scope, fg, ...)
-    " bg, attr_list, special
-    let l:bg = get(a:, 1, copy(s:none))
-    let l:attrs = a:0 >= 2 && len(a:2) > 0 ? join(a:2, ',') : 'NONE'
-    let l:special = get(a:, 3, copy(s:none))
+  " bg, attr_list, special
+  let l:bg = get(a:, 1, copy(s:none))
+  let l:attrs = a:0 >= 2 && len(a:2) > 0 ? join(a:2, ',') : 'NONE'
+  let l:special = get(a:, 3, copy(s:none))
 
-    let l:hl_string = [
+  let l:hl_string = [
         \ 'highlight', a:scope,
         \ 'guifg=' . a:fg[0], 'ctermfg=' . a:fg[1],
         \ 'guibg=' . l:bg[0], 'ctermbg=' . l:bg[1],
         \ 'gui=' . l:attrs, 'cterm=' . l:attrs,
         \ 'guisp=' . l:special[0],
         \]
-    execute join(l:hl_string, ' ')
+  execute join(l:hl_string, ' ')
 endfunction
 
-set background=dark
+" Dracula Highlight Groups: {{{2
 
-" Section: Dracula Highlight Groups {{{
-
-" FIXME: Add override for this for various terminals
-highlight Normal guibg=#282A36 guifg=#F8F8F2 ctermfg=NONE ctermbg=NONE
+call s:h('DraculaBgLight', s:none, s:bglight)
+call s:h('DraculaBgLighter', s:none, s:bglighter)
+call s:h('DraculaBgDark', s:none, s:bgdark)
+call s:h('DraculaBgDarker', s:none, s:bgdarker)
 
 call s:h('DraculaFg', s:fg)
 call s:h('DraculaFgUnderline', s:fg, s:none, ['underline'])
-
+call s:h('DraculaFgBold', s:fg, s:none, ['bold'])
 
 call s:h('DraculaComment', s:comment)
 call s:h('DraculaCommentBold', s:comment, s:none, ['bold'])
-call s:h('DraculaSelection', s:selection)
+
+call s:h('DraculaSelection', s:none, s:selection)
+
+call s:h('DraculaSubtle', s:subtle)
 
 call s:h('DraculaCyan', s:cyan)
 call s:h('DraculaCyanItalic', s:cyan, s:none, ['italic'])
-call s:h('DraculaGreen', s:green)
-call s:h('DraculaOrange', s:orange)
-call s:h('DraculaPink', s:pink)
-call s:h('DraculaPurple', s:purple)
-call s:h('DraculaPurple', s:purple)
-call s:h('DraculaRed', s:red)
-call s:h('DraculaYellow', s:yellow)
 
-" TODO: should this also be inverted?
-call s:h('DraculaError', s:red, s:none, ['undercurl'])
-call s:h('DraculaTodo', s:green, s:none, ['bold', 'inverse'])
+call s:h('DraculaGreen', s:green)
+call s:h('DraculaGreenBold', s:green, s:none, ['bold'])
+call s:h('DraculaGreenItalic', s:green, s:none, ['italic'])
+call s:h('DraculaGreenItalicUnderline', s:green, s:none, ['italic', 'underline'])
+
+call s:h('DraculaOrange', s:orange)
+call s:h('DraculaOrangeBold', s:orange, s:none, ['bold'])
+call s:h('DraculaOrangeItalic', s:orange, s:none, ['italic'])
+call s:h('DraculaOrangeBoldItalic', s:orange, s:none, ['bold', 'italic'])
+call s:h('DraculaOrangeInverse', s:bg, s:orange)
+
+call s:h('DraculaPink', s:pink)
+call s:h('DraculaPinkItalic', s:pink, s:none, ['italic'])
+
+call s:h('DraculaPurple', s:purple)
+call s:h('DraculaPurpleBold', s:purple, s:none, ['bold'])
+call s:h('DraculaPurpleItalic', s:purple, s:none, ['italic'])
+
+call s:h('DraculaRed', s:red)
+call s:h('DraculaRedInverse', s:fg, s:red)
+
+call s:h('DraculaYellow', s:yellow)
+call s:h('DraculaYellowItalic', s:yellow, s:none, ['italic'])
+
+call s:h('DraculaError', s:red, s:none, ['undercurl'], s:red)
+call s:h('DraculaWarn', s:orange, s:none, ['undercurl'], s:orange)
+
+call s:h('DraculaErrorLine', s:none, s:none, ['undercurl'], s:red)
+call s:h('DraculaWarnLine', s:none, s:none, ['undercurl'], s:orange)
+call s:h('DraculaInfoLine', s:none, s:none, ['undercurl'], s:cyan)
+
+call s:h('DraculaTodo', s:cyan, s:none, ['bold', 'inverse'])
+call s:h('DraculaSearch', s:green, s:none, ['inverse'])
+call s:h('DraculaBoundary', s:comment, s:bgdark)
+call s:h('DraculaLink', s:cyan, s:none, ['underline'])
+
+call s:h('DraculaDiffChange', s:none, s:none)
+call s:h('DraculaDiffText', s:bg, s:orange)
+call s:h('DraculaDiffDelete', s:red, s:bgdark)
+
+" }}}2
 
 " }}}
+" User Interface: {{{
 
-" Section: UI {{{
+" Core: {{{2
+set background=dark
 
+call s:h('Normal', s:fg, s:bg)
+hi! link Visual DraculaSelection
+hi! link VisualNOS Visual
+hi! link Search DraculaSearch
+hi! link IncSearch DraculaOrangeInverse
+
+" Status / Command Line
+call s:h('StatusLine', s:none, s:bglighter, ['bold'])
+call s:h('StatusLineNC', s:none, s:bglight)
+call s:h('WildMenu', s:bg, s:purple, ['bold'])
+
+" Tabs
+call s:h('TabLine', s:comment, s:bgdark)
+hi! link TabLineFill DraculaBgDarker
+hi! link TabLineSel Normal
+
+" Popup Menu
+hi! link Pmenu DraculaBgDark
+hi! link PmenuSel DraculaSelection
+hi! link PmenuSbar DraculaBgDark
+hi! link PmenuThumb DraculaSelection
+
+" Messages
+hi! link ErrorMsg DraculaRedInverse
+hi! link WarningMsg DraculaOrangeInverse
+hi! link MoreMsg DraculaFgBold
+hi! link Question DraculaFgBold
+hi! link Title DraculaGreenBold
+
+" Folds
+hi! link Folded DraculaBoundary
+hi! link VertSplit DraculaBoundary
+hi! link FoldColumn DraculaSubtle
+
+" Line Numbers
+hi! link CursorLineNr DraculaYellow
 hi! link LineNr DraculaComment
 
-" }}}
+" Whitespace / Non-text
+hi! link NonText DraculaSubtle
+hi! link CursorLine DraculaSelection
+hi! link CursorColumn DraculaSelection
+hi! link ColorColumn DraculaSelection
 
-" Section: Generic Syntax {{{
+" Diffs
+hi! link DiffAdd DraculaGreen
+hi! link DiffChange DraculaDiffChange
+hi! link DiffText DraculaDiffText
+hi! link DiffDelete DraculaDiffDelete
+
+"}}}2
+" NetRW: {{{2
+
+hi! link Directory DraculaPurpleBold
+
+" }}}2
+" GitGutter: {{{2
+hi! link GitGutterAdd DraculaGreen
+hi! link GitGutterChange DraculaYellow
+hi! link GitGutterChangeDelete DraculaOrange
+hi! link GitGutterDelete DraculaRed
+"}}}2
+
+" }}}
+" Syntax: {{{
 
 hi! link Comment DraculaComment
-hi! link Folded DraculaCommentBold
 hi! link Underlined DraculaFgUnderline
-hi! link Error DraculaError
 hi! link Todo DraculaTodo
 
-" TODO: What is this exactly?
-" 	*Ignore		left blank, hidden  |hl-Ignore|
+hi! link Error DraculaError
+hi! link SpellBad DraculaErrorLine
+hi! link SpellLocal DraculaWarnLine
+hi! link SpellCap DraculaInfoLine
+hi! link SpellRare DraculaInfoLine
 
 hi! link Constant DraculaPurple
 hi! link String DraculaYellow
@@ -142,296 +265,92 @@ hi! link Typedef DraculaPink
 
 hi! link Type DraculaCyanItalic
 
-" TODO: need a consensus here
-" 	*Special	any special symbol
-" 	 SpecialChar	special character in a constant
-" 	 Tag		you can use CTRL-] on this
-" 	 Delimiter	character that needs attention
-" 	 SpecialComment	special things inside a comment
-" 	 Debug		debugging statements
+hi! link Delimiter DraculaFg
 
+hi! link Special DraculaPink
+hi! link SpecialKey DraculaRed
+hi! link SpecialComment DraculaCyanItalic
+hi! link Tag DraculaCyan
+hi! link helpHyperTextJump DraculaLink
+hi! link helpCommand DraculaPurple
+hi! link helpExample DraculaGreen
 
-" }}}
+call s:h('MatchParen', s:none, s:pink, ['underline'])
+call s:h('Conceal', s:comment, s:bglight)
 
-" TODO {{{
+" CSS: {{{2
 
-"ColorColumn	used for the columns set with 'colorcolumn'
-"							*hl-Conceal*
-"Conceal		placeholder characters substituted for concealed
-"		text (see 'conceallevel')
-"							*hl-Cursor*
-"Cursor		the character under the cursor
-"							*hl-CursorIM*
-"CursorIM	like Cursor, but used when in IME mode |CursorIM|
-"							*hl-CursorColumn*
-"CursorColumn	the screen column that the cursor is in when 'cursorcolumn' is
-"		set
-"							*hl-CursorLine*
-"CursorLine	the screen line that the cursor is in when 'cursorline' is
-"		set
-"							*hl-Directory*
-"Directory	directory names (and other special names in listings)
-"							*hl-DiffAdd*
-"DiffAdd		diff mode: Added line |diff.txt|
-"							*hl-DiffChange*
-"DiffChange	diff mode: Changed line |diff.txt|
-"							*hl-DiffDelete*
-"DiffDelete	diff mode: Deleted line |diff.txt|
-"							*hl-DiffText*
-"DiffText	diff mode: Changed text within a changed line |diff.txt|
-"						 {Nvim} *hl-EndOfBuffer*
-"EndOfBuffer	filler lines (~) after the end of the buffer.
-"		By default, this is highlighted like |hl-NonText|.
-"						 {Nvim} *hl-TermCursor*
-"TermCursor	cursor in a focused terminal
-"						 {Nvim} *hl-TermCursorNC*
-"TermCursorNC	cursor in an unfocused terminal
-"							*hl-ErrorMsg*
-"ErrorMsg	error messages on the command line
-"							*hl-VertSplit*
-"VertSplit	the column separating vertically split windows
-"							*hl-Folded*
-"Folded		line used for closed folds
-"							*hl-FoldColumn*
-"FoldColumn	'foldcolumn'
-"							*hl-SignColumn*
-"SignColumn	column where |signs| are displayed
-"							*hl-IncSearch*
-"IncSearch	'incsearch' highlighting; also used for the text replaced with
-"		":s///c"
-"							*hl-Substitute*
-"Substitute	|:substitute| replacement text highlighting
+hi! link cssAttrComma Delimiter
+hi! link cssBraces Delimiter
+hi! link cssSelectorOp Delimiter
+hi! link cssFunctionComma Delimiter
+hi! link cssAttributeSelector DraculaGreenItalic
+hi! link cssAttrRegion DraculaPink
+hi! link cssUnitDecorators DraculaPink
+hi! link cssProp DraculaCyan
+hi! link cssPseudoClassId DraculaGreenItalic
 
-"							*hl-LineNr*
-"LineNr		Line number for ":number" and ":#" commands, and when 'number'
-"		or 'relativenumber' option is set.
-"							*hl-CursorLineNr*
-"CursorLineNr	Like LineNr when 'cursorline' or 'relativenumber' is set for
-"		the cursor line.
-"							*hl-MatchParen*
-"MatchParen	The character under the cursor or just before it, if it
-"		is a paired bracket, and its match. |pi_paren.txt|
+"}}}2
+" Elixir: {{{2
 
-"							*hl-ModeMsg*
-"ModeMsg		'showmode' message (e.g., "-- INSERT --")
-"							*hl-MoreMsg*
-"MoreMsg		|more-prompt|
-"							*hl-NonText*
-"NonText		'@' at the end of the window, characters from 'showbreak'
-"		and other characters that do not really exist in the text
-"		(e.g., ">" displayed when a double-wide character doesn't
-"		fit at the end of the line). See also |hl-EndOfBuffer|.
-"							*hl-Normal*
-"Normal		normal text
-"							*hl-NormalNC*
-"NormalNC	normal text in non-current windows
-"							*hl-Pmenu*
-"Pmenu		Popup menu: normal item.
-"							*hl-PmenuSel*
-"PmenuSel	Popup menu: selected item.
-"							*hl-PmenuSbar*
-"PmenuSbar	Popup menu: scrollbar.
-"							*hl-PmenuThumb*
-"PmenuThumb	Popup menu: Thumb of the scrollbar.
-"							*hl-Question*
-"Question	|hit-enter| prompt and yes/no questions
-"							*hl-QuickFixLine*
-"QuickFixLine	Current |quickfix| item in the quickfix window. Combined with
-"                |hl-CursorLine| when the cursor is there.
-"							*hl-Search*
-"Search		Last search pattern highlighting (see 'hlsearch').
-"		Also used for similar items that need to stand out.
-"							*hl-SpecialKey*
-"SpecialKey	Unprintable characters: text displayed differently from what
-"		it really is. But not 'listchars' whitespace. |hl-Whitespace|
-"							*hl-SpellBad*
-"SpellBad	Word that is not recognized by the spellchecker. |spell|
-"		Combined with the highlighting used otherwise.
-"							*hl-SpellCap*
-"SpellCap	Word that should start with a capital. |spell|
-"		Combined with the highlighting used otherwise.
-"							*hl-SpellLocal*
-"SpellLocal	Word that is recognized by the spellchecker as one that is
-"		used in another region. |spell|
-"		Combined with the highlighting used otherwise.
-"							*hl-SpellRare*
-"SpellRare	Word that is recognized by the spellchecker as one that is
-"		hardly ever used. |spell|
-"		Combined with the highlighting used otherwise.
-"							*hl-StatusLine*
-"StatusLine	status line of current window
-"							*hl-StatusLineNC*
-"StatusLineNC	status lines of not-current windows
-"		Note: if this is equal to "StatusLine" Vim will use "^^^" in
-"		the status line of the current window.
-"							*hl-TabLine*
-"TabLine		tab pages line, not active tab page label
-"							*hl-TabLineFill*
-"TabLineFill	tab pages line, where there are no labels
-"							*hl-TabLineSel*
-"TabLineSel	tab pages line, active tab page label
-"							*hl-Title*
-"Title		titles for output from ":set all", ":autocmd" etc.
-"							*hl-Visual*
-"Visual		Visual mode selection
-" 							*hl-VisualNOS*
-"VisualNOS	Visual mode selection when vim is "Not Owning the Selection".
-"							*hl-WarningMsg*
-"WarningMsg	warning messages
-"							*hl-Whitespace*
-"Whitespace	"nbsp", "space", "tab" and "trail" in 'listchars'
-"							*hl-WildMenu*
-"WildMenu	current match in 'wildmenu' completion
-
-" }}}
-
-" FIXME: Old stuff {{{
-
-"hi Cursor ctermfg=17 ctermbg=231 cterm=NONE guifg=#282a36 guibg=#f8f8f0 gui=NONE
-"hi Visual ctermfg=NONE ctermbg=241 cterm=NONE guifg=NONE guibg=#44475a gui=NONE
-"hi CursorLine ctermbg=234 cterm=NONE guifg=NONE guibg=#44475a gui=NONE
-"hi CursorColumn ctermbg=234 cterm=NONE guifg=NONE guibg=#44475a gui=NONE
-"hi ColorColumn ctermfg=NONE ctermbg=236 cterm=NONE guifg=NONE guibg=#3d3f49 gui=NONE
-"hi LineNr ctermfg=60 ctermbg=NONE cterm=NONE guifg=#6272a4 guibg=#282a36 gui=NONE
-"hi CursorLineNr ctermfg=228 ctermbg=234 cterm=NONE guifg=#f1fa8c guibg=#44475a gui=NONE
-"hi VertSplit ctermfg=231 ctermbg=236 cterm=bold guifg=#64666d guibg=#64666d gui=bold
-"hi MatchParen ctermfg=212 ctermbg=NONE cterm=underline guifg=#ff79c6 guibg=NONE gui=underline
-"hi StatusLine ctermfg=231 ctermbg=236 cterm=bold guifg=#f8f8f2 guibg=#64666d gui=bold
-"hi StatusLineNC ctermfg=231 ctermbg=236 cterm=NONE guifg=#f8f8f2 guibg=#64666d gui=NONE
-"hi Pmenu ctermfg=15 ctermbg=61 cterm=NONE guifg=#f8f8f2 guibg=#646e96 gui=NONE
-"hi PmenuSel ctermfg=16 ctermbg=84 cterm=bold guifg=#282a36 guibg=#50fa7b gui=NONE
-"hi IncSearch ctermfg=17 ctermbg=215 cterm=none guifg=#282a36 guibg=#ffb86c gui=none
-"hi Search ctermfg=17 ctermbg=84 cterm=none guifg=#282a36 guibg=#50fa7b gui=none
-"hi Directory ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-"hi Folded ctermfg=61 ctermbg=235 cterm=NONE guifg=#6272a4 guibg=#282a36 gui=NONE
-"hi SignColumn ctermfg=246 ctermbg=235 cterm=NONE guifg=#909194 guibg=#44475a gui=NONE
-"hi FoldColumn ctermfg=246 ctermbg=235 cterm=NONE guifg=#909194 guibg=#44475a gui=NONE
-"hi Normal guifg=#f8f8f2 guibg=#282a36 gui=NONE
-"hi Boolean ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-"hi Character ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-"hi Comment ctermfg=61 ctermbg=NONE cterm=NONE guifg=#6272a4 guibg=NONE gui=NONE
-"hi Conditional ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-"hi Constant ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-"hi Define ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-"hi DiffAdd ctermfg=231 ctermbg=64 cterm=bold guifg=#f8f8f2 guibg=#468410 gui=bold
-"hi DiffDelete ctermfg=88 ctermbg=NONE cterm=NONE guifg=#8b080b guibg=NONE gui=NONE
-"hi DiffChange ctermfg=231 ctermbg=23 cterm=NONE guifg=#f8f8f2 guibg=#243a5f gui=NONE
-"hi DiffText ctermfg=231 ctermbg=24 cterm=bold guifg=#f8f8f2 guibg=#204a87 gui=bold
-"hi ErrorMsg ctermfg=231 ctermbg=212 cterm=NONE guifg=#f8f8f0 guibg=#ff79c6 gui=NONE
-"hi WarningMsg ctermfg=231 ctermbg=212 cterm=NONE guifg=#f8f8f0 guibg=#ff79c6 gui=NONE
-"hi Float ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-"hi Function ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-"hi Identifier ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
-"hi Keyword ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-"hi Label ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-"hi NonText ctermfg=231 ctermbg=NONE cterm=NONE guifg=#525563 guibg=NONE gui=NONE
-"hi Number ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-"hi Operator ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-"hi PreProc ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-"hi Special ctermfg=231 ctermbg=NONE cterm=NONE guifg=#f8f8f2 guibg=NONE gui=NONE
-"hi SpecialComment ctermfg=61 ctermbg=NONE cterm=NONE guifg=#6272a4 guibg=NONE gui=NONE
-"hi SpecialKey ctermfg=231 ctermbg=235 cterm=NONE guifg=#525563 guibg=NONE gui=NONE
-"hi Statement ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-"hi StorageClass ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
-"hi String ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-"hi SpellBad ctermfg=red ctermbg=NONE cterm=underline
-"hi Tag ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-"hi Title ctermfg=231 ctermbg=NONE cterm=bold guifg=#f8f8f2 guibg=NONE gui=bold
-"hi Todo ctermfg=61 ctermbg=NONE cterm=inverse,bold guifg=#6272a4 guibg=NONE gui=inverse,bold
-"hi Type ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
-"hi Underlined ctermfg=NONE ctermbg=NONE cterm=underline guifg=NONE guibg=NONE gui=underline
-"hi rubyClass ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-"hi rubyFunction ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-"hi rubyInterpolationDelimiter ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-"hi rubySymbol ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-"hi rubyConstant ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic
-"hi rubyStringDelimiter ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-"hi rubyBlockParameter ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic
-"hi rubyInstanceVariable ctermfg=203 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=NONE
-"hi rubyInclude ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-"hi rubyGlobalVariable ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-"hi rubyRegexp ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-"hi rubyRegexpDelimiter ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-"hi rubyEscape ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-"hi rubyControl ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-"hi rubyClassVariable ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-"hi rubyOperator ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-"hi rubyException ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-"hi rubyPseudoVariable ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-"hi rubyRailsUserClass ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic
-"hi rubyRailsARAssociationMethod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
-"hi rubyRailsARMethod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
-"hi rubyRailsRenderMethod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
-"hi rubyRailsMethod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
-"hi erubyDelimiter ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-"hi erubyComment ctermfg=61 ctermbg=NONE cterm=NONE guifg=#6272a4 guibg=NONE gui=NONE
-"hi erubyRailsMethod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
-"hi htmlTag ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-"hi htmlEndTag ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-"hi htmlTagName ctermfg=NONE ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-"hi htmlArg ctermfg=NONE ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-"hi htmlSpecialChar ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-"hi javaScriptFunction ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
-"hi javaScriptRailsFunction ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
-"hi javaScriptBraces ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-"hi yamlKey ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-"hi yamlAnchor ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-"hi yamlAlias ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-"hi yamlDocumentHeader ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-"hi cssURL ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic
-"hi cssFunctionName ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
-"hi cssColor ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-"hi cssPseudoClassId ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-"hi cssClassName ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-"hi cssValueLength ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-"hi cssCommonAttr ctermfg=81 ctermbg=NONE cterm=NONE guifg=#6be5fd guibg=NONE gui=NONE
-"hi cssBraces ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
-"hi TabLineFill  cterm=NONE ctermbg=236 guifg=#333333 guibg=#282a36 gui=none
-"hi TabLine      cterm=NONE ctermfg=7 ctermbg=240 guifg=#666666 guibg=#282a36 gui=none
-"hi TabLineSel   guifg=WHITE guibg=#282a36 gui=none
-
-"" Elixir {{{
+"TODO:
 "hi elixirAtom ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic"
 "hi elixirModuleDeclaration ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic"
 "hi elixirAlias ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE gui=italic"
 "hi elixirInterpolationDelimiter ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
 "hi elixirStringDelimiter ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-""}}}
-""
-"" Vim Script {{{
-"hi vimGroupName ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE
-"hi vimGroup ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE
-"hi vimOption ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE
-"hi vimHiCtermFgBg ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE
-"hi vimHiGuiFgBg ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE
-"" }}}
-"" Markdown: {{{
-"hi markdownH1 ctermfg=141 ctermbg=NONE cterm=bold guifg=#bd93f9 guibg=NONE gui=bold"
-"hi markdownH2 ctermfg=141 ctermbg=NONE cterm=bold guifg=#bd93f9 guibg=NONE gui=bold"
-"hi markdownH3 ctermfg=212 ctermbg=NONE cterm=bold guifg=#ff79c6 guibg=NONE gui=bold"
-"hi markdownH4 ctermfg=212 ctermbg=NONE cterm=bold guifg=#ff79c6 guibg=NONE gui=bold"
-"hi markdownH5 ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-"hi markdownH6 ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 
-"hi markdownCode ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-"hi markdownCodeBlock ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-"hi markdownCodeDelimiter ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
+"}}}2
+" HTML: {{{2
 
-"hi markdownBlockquote ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-"hi markdownListMarker ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-"hi markdownOrderedListMarker ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-"hi markdownRule ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-"hi markdownHeadingRule ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
+hi! link htmlTag DraculaFg
+hi! link htmlArg DraculaGreenItalic
+hi! link htmlTitle DraculaFg
+hi! link htmlH1 DraculaFg
+hi! link htmlSpecialChar DraculaPurple
 
-"hi markdownUrlDelimiter ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic"
-"hi markdownLinkDelimiter ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic"
-"hi markdownLinkTextDelimiter ctermfg=215 ctermbg=NONE cterm=NONE guifg=#ffb86c guibg=NONE gui=italic"
+"}}}2
+" JavaScript: {{{2
 
-"hi markdownHeadingDelimiter ctermfg=117 ctermbg=NONE cterm=bold guifg=#8be9fd guibg=NONE gui=bold"
-"hi markdownUrl ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
-"hi markdownUrlTitleDelimiter ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
-"" }}}
-"" OCaml {{{
+"TODO:
+"hi javaScriptFunction ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
+"hi javaScriptRailsFunction ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
+"hi javaScriptBraces ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+
+"}}}2
+" Markdown: {{{2
+
+hi! link markdownH1 DraculaPurpleBold
+hi! link markdownH2 markdownH1
+hi! link markdownH3 markdownH1
+hi! link markdownH4 markdownH1
+hi! link markdownH5 markdownH1
+hi! link markdownH6 markdownH1
+hi! link markdownHeadingDelimiter markdownH1
+hi! link markdownHeadingRule markdownH1
+
+hi! link markdownBold DraculaOrangeBold
+hi! link markdownItalic DraculaYellowItalic
+hi! link markdownBoldItalic DraculaOrangeBoldItalic
+
+hi! link markdownBlockquote DraculaCyan
+
+hi! link markdownCode DraculaGreenItalic
+hi! link markdownCodeDelimiter DraculaGreen
+hi! link markdownCodeBlock DraculaYellow
+
+hi! link markdownListMarker DraculaCyan
+hi! link markdownOrderedListMarker DraculaCyan
+
+hi! link markdownRule DraculaComment
+
+hi! link markdownLinkText DraculaPink
+hi! link markdownUrl DraculaLink
+
+"}}}2
+" OCaml: {{{2
+
+"TODO:
 "hi ocamlModule ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
 "hi ocamlConstructor ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
 "hi ocamlType ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
@@ -441,32 +360,42 @@ hi! link Type DraculaCyanItalic
 "hi ocamlFullMod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
 "hi ocamlWith ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
 "hi ocamlUnit ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
-"" }}}
 
-"" Neovim Terminal Colors {{{
-"if has("nvim")
-"  let g:terminal_color_0 = "#000000"
-"  let g:terminal_color_1 = "#FF5555"
-"  let g:terminal_color_2 = "#50FA7B"
-"  let g:terminal_color_3 = "#F1FA8C"
-"  let g:terminal_color_4 = "#BD93F9"
-"  let g:terminal_color_5 = "#FF79C6"
-"  let g:terminal_color_6 = "#8BE9FD"
-"  let g:terminal_color_7 = "#BFBFBF"
-"  let g:terminal_color_8 = "#4D4D4D"
-"  let g:terminal_color_9 = "#FF6E67"
-"  let g:terminal_color_10 = "#5AF78E"
-"  let g:terminal_color_11 = "#F4F99D"
-"  let g:terminal_color_12 = "#CAA9FA"
-"  let g:terminal_color_13 = "#FF92D0"
-"  let g:terminal_color_14 = "#9AEDFE"
-"  let g:terminal_color_15 = "#E6E6E6"
-"endif
-"" }}}
+"}}}2
+" Ruby: {{{2
 
-" TODO: Verify this
-" Must be at EOF. See: https://groups.google.com/forum/#!msg/vim_dev/afPqwAFNdrU/nqh6tOM87QUJ
-" set background=dark
+let g:ruby_operators=1
+hi! link rubyStringDelimiter DraculaYellow
+hi! link rubyInterpolationDelimiter DraculaPink
+hi! link rubyCurlyBlock DraculaPink
+hi! link rubyBlockParameter DraculaOrangeItalic
+hi! link rubyBlockArgument DraculaOrangeItalic
+hi! link rubyInstanceVariable DraculaPurpleItalic
+hi! link rubyGlobalVariable DraculaPurple
+hi! link rubyRegexpDelimiter DraculaRed
 
-" }}}
+"}}}2
+" YAML: {{{2
 
+hi! link yamlBlockMappingKey DraculaCyan
+hi! link yamlPlainScalar DraculaYellow
+hi! link yamlAnchor DraculaPinkItalic
+hi! link yamlAlias DraculaGreenItalicUnderline
+hi! link yamlNodeTag DraculaPink
+hi! link yamlFlowCollection DraculaPink
+hi! link yamlFlowIndicator Delimiter
+
+"}}}2
+" Vim Script: {{{2
+
+"TODO:
+"hi vimGroupName ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE
+"hi vimGroup ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE
+"hi vimOption ctermfg=81 ctermbg=NONE cterm=NONE guifg=#66d9ef guibg=NONE
+"hi vimHiCtermFgBg ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE
+"hi vimHiGuiFgBg ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE
+
+"}}}2
+"}}}
+
+" vim: fdm=marker ts=2 sts=2 sw=2:

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -327,7 +327,6 @@ hi! link markdownBlockquote DraculaCyan
 
 hi! link markdownCode DraculaGreenItalic
 hi! link markdownCodeDelimiter DraculaGreen
-hi! link markdownCodeBlock DraculaYellow
 
 hi! link markdownListMarker DraculaCyan
 hi! link markdownOrderedListMarker DraculaCyan

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -239,6 +239,7 @@ hi! link FoldColumn DraculaSubtle
 " Line Numbers
 hi! link CursorLineNr DraculaYellow
 hi! link LineNr DraculaComment
+hi! link SignColumn DraculaComment
 
 " Whitespace / Non-text
 call s:h('CursorLine', s:none, s:subtle) " Required as some plugins will overwrite

--- a/doc/dracula.txt
+++ b/doc/dracula.txt
@@ -1,0 +1,137 @@
+*dracula.txt*           For Vim version 8           Last change: 2018 March 27
+*dracula* *vim-dracula*
+
+                    |\                          ,,       ~
+                    \\          _              ||   _   ~
+                    / \\ ,._-_  < \,  _-_ \\ \\ ||  < \, ~
+                   || ||  ||    /-|| ||   || || ||  /-|| ~
+                   || ||  ||   (( || ||   || || || (( || ~
+                    \\/   \\,   \/\\ \\,/ \\/\\ \\  \/\\ ~
+
+                             A dark theme for vim
+
+==============================================================================
+CONTENTS                                                      *dracula-contents*
+
+    1. Intro ................................................... |dracula-intro|
+    2. Usage ................................................... |dracula-usage|
+    3. Configuration ................................... |dracula-configuration|
+    4. Personal Customization .......................... |dracula-customization|
+    5. License ............................................... |dracula-license|
+    6. Bugs ..................................................... |dracula-bugs|
+    7. Contributing ..................................... |dracula-contributing|
+    8. Credits ............................................... |dracula-credits|
+
+==============================================================================
+INTRO                                                            *dracula-intro*
+
+Dracula is a vim plugin that contains
+
+    - a dark colorscheme for vim
+    - a similarly-themed colorscheme for the vim plugin airline
+        (https://github.com/vim-airline/vim-airline)
+
+==============================================================================
+USAGE                                                            *dracula-usage*
+
+Install it with your favorite plugin manager, and then >
+    colorscheme dracula
+in your vimrc !
+
+If you are an airline user, you can also do >
+    let g:airline_theme='dracula'
+to have airline use Dracula.
+
+==============================================================================
+CONFIGURATION                                            *dracula-configuration*
+
+There are a couple of variables used by Dracula that you might want to adjust
+depending on your terminal's capabilities.
+
+Default values are shown.
+
+------------------------------------------------------------------------------
+In the following section, `1` signifies `on` and `0` signifies `off`.
+
+* *g:dracula_bold*
+Include bold attributes in highlighting >
+    let g:dracula_bold = 1
+<
+* *g:dracula_italic*
+Include italic attributes in highlighting >
+    let g:dracula_italic = 1
+<
+* *g:dracula_underline*
+Include underline attributes in highlighting >
+    let g:dracula_underline = 1
+<
+* *g:dracula_undercurl*
+Include undercurl attributes in highlighting (only if underline enabled) >
+    let g:dracula_undercurl = 1
+<
+* *g:dracula_inverse*
+Include inverse attributes in highlighting >
+    let g:dracula_inverse = 1
+<
+==============================================================================
+CUSTOMIZATION                                            *dracula-customization*
+
+Like all colorschemes, Dracula is easy to customize with |autocmd|. Make use
+of the |ColorScheme| event as in the following examples.
+
+It would be a good idea to put all of your personal changes in an |augroup|,
+which you can do with the following code: >
+    augroup dracula_customization
+      au!
+      " autocmds...
+    augroup END
+>
+
+- To add underline styling to |hl-CursorLine|, you can use the following: >
+    autocmd ColorScheme dracula hi CursorLine cterm=underline term=underline
+<
+==============================================================================
+LICENSE                                                        *dracula-license*
+
+MIT License. Copyright © 2016 Dracula Theme.
+Full text available at
+https://github.com/dracula/vim/blob/master/LICENSE
+
+==============================================================================
+BUGS                                                              *dracula-bugs*
+
+At the time of this writing, no major bugs have been found.
+
+If you find one and wish to report it, you can do so at
+https://github.com/dracula/vim/issues
+
+==============================================================================
+CONTRIBUTING                                              *dracula-contributing*
+
+Want to submit a new feature, bugfix, or hack on Dracula?
+Submit pull requests to
+https://github.com/dracula/vim/pulls
+
+Existing code determines style guidelines.
+
+==============================================================================
+CREDITS                                                        *dracula-credits*
+
+Proudly built by the Dracula Theme organization
+https://github.com/dracula
+
+Dracula for other applications available at
+https://draculatheme.com
+
+Further information available at
+https://draculatheme.com/vim
+
+Maintained by:
+- Trevor Heins ( https://github.com/heinst )
+- Blake Williams ( https://github.com/BlakeWilliams )
+- Derek S. ( https://github.com/dsifford )
+
+Git repository:
+https://github.com/dracula/vim
+
+ vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
This PR is an attempt to normalize the Vim Dracula implementation in its current form according to the running [specification](https://dsifford.github.io/dracula-spec/) that I [proposed](https://github.com/dracula/dracula-theme/issues/232) in the main repository.

The PR is a baseline for further scrutinization. It is in no way complete, however I did have the opportunity to test and confirm all the languages that were explicitly targeted in the existing implementation are highlighted appropriately in accordance to the above specification.

Along with the obvious fact that this is more or less a complete rewrite, the following notible changes were made:

- Several dozen custom `Dracula<xxx>` highlight scopes were made, which existing highlight scopes are then linked to to allow for slightly better startup performance and, more importantly, easier debugging with `:hi<CR>`
- This introduces several user customizations that allows users to disable text style attributes if they don't want them or their terminals don't support them (underline, italic, bold, undercurl, inverse).

Anyway, I'll leave it at that for now. Curious to hear what you all think.

Closes #25
Closes #37
Closes #45
Closes #46
Closes #48
Closes #50

Also, this negates the need for #42, so that can probably be closed.

CC: @zenorocha, @benknoble