### PR TITLE
add support for plasticboy/vim-markdown syntax

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -386,7 +386,7 @@ hi! link markdownBoldItalic DraculaOrangeBoldItalic
 
 hi! link markdownBlockquote DraculaCyan
 
-hi! link markdownCode DraculaGreenItalic
+hi! link markdownCode DraculaGreen
 hi! link markdownCodeDelimiter DraculaGreen
 
 hi! link markdownListMarker DraculaCyan

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -1,0 +1,32 @@
+
+
+" plasticboy/vim-markdown {{{1
+
+hi! link htmlH1 DraculaPurpleBold
+
+hi! link htmlItalic DraculaYellowItalic
+hi! link mkdItalic DraculaYellowItalic
+
+hi! link htmlBold DraculaOrangeBold
+hi! link mkdBold DraculaOrangeBold
+
+hi! link htmlBoldItalic DraculaOrangeBoldItalic
+hi! link mkdBoldItalic DraculaOrangeBoldItalic
+
+hi! link mkdRule DraculaComment
+
+hi! link mkdBlockquote DraculaYellowItalic
+
+hi! link mkdListItem DraculaCyan
+
+hi! link mkdCode DraculaGreen
+hi! link mkdCodeStart DraculaGreen
+hi! link mkdCodeEnd DraculaGreen
+
+hi! link mkdLink DraculaPink
+hi! link mkdUrl DraculaLink
+hi! link mkdInlineUrl DraculaLink
+
+"}}}1
+
+" vim: fdm=marker ts=2 sts=2 sw=2:

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -1,5 +1,3 @@
-
-
 " plasticboy/vim-markdown {{{1
 
 hi! link htmlH1 DraculaPurpleBold


### PR DESCRIPTION
This is the first of many planned syntax extensions to provide better syntax highlighting support in accordance to the running spec.

Because this syntax uses a lot of the built-in html highlight groups, it needed to be done as a ftplugin so that the highlight tweaks only apply for markdown.

This begs the question: Should we be doing most/all of the syntax highlighting as ftplugins? Would that offer better performance?

Let me know what you think @benknoble

Also -- @zenorocha Can we add @benknoble as a maintainer here? And if possible, can we remove the other two listed maintainers? I tried reaching out to both of them twice now with no reply. I think it's safe to say they've lost interest.

Thanks :+1: