### PR TITLE
add support for fzf

### DIFF
--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -1,0 +1,26 @@
+" Fzf: {{{
+if exists('g:loaded_fzf') && ! exists('g:fzf_colors')
+  let g:fzf_colors = {
+        \ 'fg':      ['fg', 'Normal'],
+        \ 'bg':      ['bg', 'Normal'],
+        \ 'hl':      ['fg', 'Search'],
+        \ 'fg+':     ['fg', 'Normal'],
+        \ 'bg+':     ['bg', 'Normal'],
+        \ 'hl+':     ['fg', 'DraculaOrange'],
+        \ 'info':    ['fg', 'DraculaPurple'],
+        \ 'border':  ['fg', 'Ignore'],
+        \ 'prompt':  ['fg', 'DraculaGreen'],
+        \ 'pointer': ['fg', 'Exception'],
+        \ 'marker':  ['fg', 'Keyword'],
+        \ 'spinner': ['fg', 'Label'],
+        \ 'header':  ['fg', 'Comment'] }
+
+  augroup dracula_fzf
+    autocmd!
+    autocmd  FileType fzf set laststatus=0 noshowmode noruler
+          \| autocmd BufLeave <buffer> set laststatus=2 showmode ruler
+  augroup END
+endif
+"}}}
+
+" vim: fdm=marker ts=2 sts=2 sw=2:

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -278,17 +278,17 @@ hi! link DiffText DraculaDiffText
 hi! link DiffDelete DraculaDiffDelete
 
 "}}}2
-" NetRW: {{{2
-
-hi! link Directory DraculaPurpleBold
-
-" }}}2
 " GitGutter: {{{2
 hi! link GitGutterAdd DraculaGreen
 hi! link GitGutterChange DraculaYellow
 hi! link GitGutterChangeDelete DraculaOrange
 hi! link GitGutterDelete DraculaRed
 "}}}2
+" NetRW: {{{2
+
+hi! link Directory DraculaPurpleBold
+
+" }}}2
 
 " }}}
 " Syntax: {{{


### PR DESCRIPTION
This adds support for [fzf](https://github.com/junegunn/fzf) (see also: [fzf-vim](https://github.com/junegunn/fzf.vim/)) if the user has it installed.

The implementation only applies if the user has fzf installed and enabled. To get this to work properly, the implementation needed to occur in `after/plugin`, hence the new runtime folder additions.

**Before:**
![image](https://user-images.githubusercontent.com/5240018/39090725-c97ffb86-45b4-11e8-9c1f-2d8ae57c83d5.png)

**After:**
![image](https://user-images.githubusercontent.com/5240018/39090716-a7b76c50-45b4-11e8-983e-4ebf91dbf26f.png)

cc: @benknoble 