### PR TITLE
Always set background colour when running gui.

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -225,7 +225,7 @@ call s:h('DraculaDiffDelete', s:red, s:bgdark)
 
 " Core: {{{2
 set background=dark
-call s:h('Normal', s:fg, g:dracula_colorterm == 1 ? s:bg : s:none)
+call s:h('Normal', s:fg, ( (g:dracula_colorterm == 1) || has("gui_running") ) ? s:bg : s:none)
 
 hi! link Visual DraculaSelection
 hi! link VisualNOS Visual

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -156,6 +156,14 @@ function! s:h(scope, fg, ...) " bg, attr_list, special
   execute join(l:hl_string, ' ')
 endfunction
 
+function! s:Background()
+  if g:dracula_colorterm || has("gui_running")
+    return s:bg
+  else
+    return s:none
+  endif
+endfunction
+
 "}}}2
 " Dracula Highlight Groups: {{{2
 
@@ -225,7 +233,7 @@ call s:h('DraculaDiffDelete', s:red, s:bgdark)
 
 " Core: {{{2
 set background=dark
-call s:h('Normal', s:fg, ( (g:dracula_colorterm == 1) || has("gui_running") ) ? s:bg : s:none)
+call s:h('Normal', s:fg, s:Background())
 
 hi! link Visual DraculaSelection
 hi! link VisualNOS Visual


### PR DESCRIPTION
Setting 'g:dracula_colorterm' to '0' to get a transparent background in the terminal also sets the gui background to 'none' and breaks gvim. (The gvim background ends up white).

Changed the call to the Normal highlight group to always set the background colour if the gui is running, regardless of the terminal setting.
