### PR TITLE
address issues #82, #83, #84

### DIFF
--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -1,7 +1,3 @@
-augroup dracula_fzf
-  autocmd!
-augroup END
-
 if dracula#should_abort()
   finish
 endif
@@ -22,14 +18,6 @@ if exists('g:loaded_fzf') && ! exists('g:fzf_colors')
         \ 'marker':  ['fg', 'Keyword'],
         \ 'spinner': ['fg', 'Label'],
         \ 'header':  ['fg', 'Comment'] }
-
-  let s:laststatus = &laststatus
-  let s:showmode = &showmode == 0 ? 'showmode' : 'noshowmode'
-  let s:ruler = &ruler == 0 ? 'ruler' : 'noruler'
-  augroup dracula_fzf
-    autocmd  FileType fzf set laststatus=0 noshowmode noruler
-          \| autocmd BufLeave <buffer> exec 'set laststatus=' .s:laststatus . ' ' . s:showmode . ' ' . s:ruler
-  augroup END
 endif
 "}}}
 " GitGutter: {{{

--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -1,3 +1,11 @@
+augroup dracula_fzf
+  autocmd!
+augroup END
+
+if ! exists('g:colors_name') || g:colors_name !=# 'dracula'
+  finish
+endif
+
 " Fzf: {{{
 if exists('g:loaded_fzf') && ! exists('g:fzf_colors')
   let g:fzf_colors = {
@@ -15,15 +23,19 @@ if exists('g:loaded_fzf') && ! exists('g:fzf_colors')
         \ 'spinner': ['fg', 'Label'],
         \ 'header':  ['fg', 'Comment'] }
 
+  let s:laststatus = &laststatus
+  let s:showmode = &showmode == 0 ? 'showmode' : 'noshowmode'
+  let s:ruler = &ruler == 0 ? 'ruler' : 'noruler'
   augroup dracula_fzf
-    autocmd!
     autocmd  FileType fzf set laststatus=0 noshowmode noruler
-          \| autocmd BufLeave <buffer> set laststatus=2 showmode ruler
+          \| autocmd BufLeave <buffer> exec 'set laststatus=' .s:laststatus . ' ' . s:showmode . ' ' . s:ruler
   augroup END
 endif
 "}}}
 " GitGutter: {{{
 
+" FIXME: This can be removed once airblade/vim-gitgutter#520 closes
+" see: https://github.com/airblade/vim-gitgutter/issues/520#issuecomment-389931281
 if exists('g:gitgutter_enabled')
   hi! link GitGutterAdd DraculaGreen
   hi! link GitGutterChange DraculaYellow

--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -2,7 +2,7 @@ augroup dracula_fzf
   autocmd!
 augroup END
 
-if ! exists('g:colors_name') || g:colors_name !=# 'dracula'
+if dracula#should_abort()
   finish
 endif
 

--- a/after/syntax/css.vim
+++ b/after/syntax/css.vim
@@ -1,4 +1,4 @@
-if ! exists('b:current_syntax') || b:current_syntax !=# 'css'
+if dracula#should_abort('css')
     finish
 endif
 

--- a/after/syntax/gitcommit.vim
+++ b/after/syntax/gitcommit.vim
@@ -1,4 +1,4 @@
-if ! exists('b:current_syntax') || b:current_syntax !=# 'gitcommit'
+if dracula#should_abort('gitcommit')
     finish
 endif
 

--- a/after/syntax/html.vim
+++ b/after/syntax/html.vim
@@ -1,4 +1,4 @@
-if ! exists('b:current_syntax') || b:current_syntax !=# 'html'
+if dracula#should_abort('html')
     finish
 endif
 

--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -1,4 +1,4 @@
-if ! exists('b:current_syntax') || b:current_syntax !=# 'javascript'
+if dracula#should_abort('javascript')
     finish
 endif
 

--- a/after/syntax/markdown.vim
+++ b/after/syntax/markdown.vim
@@ -1,5 +1,5 @@
-if ! exists('b:current_syntax')
-  finish
+if dracula#should_abort('markdown', 'mkd')
+    finish
 endif
 
 if b:current_syntax ==# 'mkd'

--- a/after/syntax/ocaml.vim
+++ b/after/syntax/ocaml.vim
@@ -1,4 +1,4 @@
-if ! exists('b:current_syntax') || b:current_syntax !=# 'ocaml'
+if dracula#should_abort('ocaml')
     finish
 endif
 

--- a/after/syntax/php.vim
+++ b/after/syntax/php.vim
@@ -1,4 +1,4 @@
-if ! exists('b:current_syntax') || b:current_syntax !=# 'php'
+if dracula#should_abort('php')
     finish
 endif
 

--- a/after/syntax/ruby.vim
+++ b/after/syntax/ruby.vim
@@ -1,4 +1,4 @@
-if ! exists('b:current_syntax') || b:current_syntax !=# 'ruby'
+if dracula#should_abort('ruby')
     finish
 endif
 

--- a/after/syntax/sass.vim
+++ b/after/syntax/sass.vim
@@ -1,4 +1,4 @@
-if ! exists('b:current_syntax') || b:current_syntax !=# 'sass'
+if dracula#should_abort('sass')
     finish
 endif
 

--- a/after/syntax/typescript.vim
+++ b/after/syntax/typescript.vim
@@ -1,4 +1,4 @@
-if ! exists('b:current_syntax') || b:current_syntax !=# 'typescript'
+if dracula#should_abort('typescript')
     finish
 endif
 

--- a/after/syntax/typescriptreact.vim
+++ b/after/syntax/typescriptreact.vim
@@ -1,4 +1,4 @@
-if ! exists('b:current_syntax') || b:current_syntax !=# 'typescriptreact'
+if dracula#should_abort('typescriptreact')
     finish
 endif
 

--- a/after/syntax/vim.vim
+++ b/after/syntax/vim.vim
@@ -1,4 +1,4 @@
-if ! exists('b:current_syntax') || b:current_syntax !=# 'vim'
+if dracula#should_abort('vim')
     finish
 endif
 

--- a/after/syntax/yaml.vim
+++ b/after/syntax/yaml.vim
@@ -1,4 +1,4 @@
-if ! exists('b:current_syntax') || b:current_syntax !=# 'yaml'
+if dracula#should_abort('yaml')
     finish
 endif
 

--- a/autoload/dracula.vim
+++ b/autoload/dracula.vim
@@ -1,5 +1,10 @@
 " Helper function that takes a variadic list of filetypes as args and returns
 " whether or not the execution of the ftplugin should be aborted.
 func! dracula#should_abort(...)
-    return ! exists('b:current_syntax') || index(a:000, b:current_syntax) < 0 || ! exists('g:colors_name') || g:colors_name !=# 'dracula'
+    if ! exists('g:colors_name') || g:colors_name !=# 'dracula'
+        return 1
+    elseif a:0 > 0 && (! exists('b:current_syntax') || index(a:000, b:current_syntax) == -1)
+        return 1
+    endif
+    return 0
 endfunction

--- a/autoload/dracula.vim
+++ b/autoload/dracula.vim
@@ -1,0 +1,5 @@
+" Helper function that takes a variadic list of filetypes as args and returns
+" whether or not the execution of the ftplugin should be aborted.
+func! dracula#should_abort(...)
+    return ! exists('b:current_syntax') || index(a:000, b:current_syntax) < 0 || ! exists('g:colors_name') || g:colors_name !=# 'dracula'
+endfunction

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -210,8 +210,7 @@ call s:h('DraculaRedInverse', s:fg, s:red)
 call s:h('DraculaYellow', s:yellow)
 call s:h('DraculaYellowItalic', s:yellow, s:none, [s:attrs.italic])
 
-call s:h('DraculaError', s:red, s:none, [s:attrs.undercurl], s:red)
-call s:h('DraculaWarn', s:orange, s:none, [s:attrs.undercurl], s:orange)
+call s:h('DraculaError', s:red, s:none, [], s:red)
 
 call s:h('DraculaErrorLine', s:none, s:none, [s:attrs.undercurl], s:red)
 call s:h('DraculaWarnLine', s:none, s:none, [s:attrs.undercurl], s:orange)


### PR DESCRIPTION
This is the first shot at handling #82 & #83 in a manner that doesn't require us to completely refactor the entire codebase.

The links still remain when the colorscheme is switched from dracula to something else, but I still don't think that is cause for us to refactor the entire package to not using links at all because this is such a rare occasion and also because all the person has to do is restart vim.

It is possible to make this a clean swap by not using links, but it would dramatically increase the startup time because we'd have to use function calls to set the colors for each and every modification.

cc: @benknoble

Closes #82 
Closes #83 
Closes #84 