### PR TITLE
Fix end tag in xml not being highlighted

### DIFF
--- a/after/syntax/xml.vim
+++ b/after/syntax/xml.vim
@@ -1,0 +1,7 @@
+if dracula#should_abort('xml')
+    finish
+endif
+
+hi! link xmlTag DraculaGreen
+hi! link xmlEndTag DraculaGreen
+

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -326,8 +326,6 @@ hi! link helpHyperTextJump DraculaLink
 hi! link helpCommand DraculaPurple
 hi! link helpExample DraculaGreen
 
-hi! link xmlEndTag xmlTag
-
 "}}}
 
 " vim: fdm=marker ts=2 sts=2 sw=2:

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -326,6 +326,8 @@ hi! link helpHyperTextJump DraculaLink
 hi! link helpCommand DraculaPurple
 hi! link helpExample DraculaGreen
 
+hi! link xmlEndTag xmlTag
+
 "}}}
 
 " vim: fdm=marker ts=2 sts=2 sw=2:


### PR DESCRIPTION
This is because, by default, vim links xmlTag to Function, xmlEndTag to Identifier.

before
![screen shot 2018-05-24 at 7 20 07 pm](https://user-images.githubusercontent.com/2883335/40482756-5fdc52ae-5f88-11e8-865b-35df8a000bbc.png)
after
![screen shot 2018-05-24 at 7 20 49 pm](https://user-images.githubusercontent.com/2883335/40482766-65bad696-5f88-11e8-968f-6f3a65284bbd.png)
 
