### PR TITLE
Added extra diff groups for adds/deletes.

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -243,8 +243,10 @@ hi! link ColorColumn  DraculaSelection
 hi! link CursorColumn DraculaSelection
 hi! link CursorLineNr DraculaYellow
 hi! link DiffAdd      DraculaGreen
+hi! link DiffAdded    DiffAdd
 hi! link DiffChange   DraculaDiffChange
 hi! link DiffDelete   DraculaDiffDelete
+hi! link DiffRemoved  DiffDelete
 hi! link DiffText     DraculaDiffText
 hi! link Directory    DraculaPurpleBold
 hi! link ErrorMsg     DraculaRedInverse


### PR DESCRIPTION
I'm not sure why this is the case, but even though the Vim help pages claim that "DiffAdd" and "DiffDelete" are the groups for diff coloring, the "DiffAdd" and "DiffDelete" links in Dracula don't seem to do anything.  Changing them to "DiffAdded" and "DiffRemoved", respectively, seem to produce the desired behavior.  I've just added an extra layer of links (e.g. linking "DiffAdded" to the pre-existing "DiffAdd") rather than changing what's there already just in case removing the originals were to break something somewhere, if that seems like a reasonable way to go about it.

(The other two diff groups, DiffChange and DiffText, seem to be right.)

Before:
![diff_pre](https://user-images.githubusercontent.com/1944536/40559788-bf3139b6-600c-11e8-9bce-100737597b4f.png)

After:
![diff_post](https://user-images.githubusercontent.com/1944536/40559792-c2a6938e-600c-11e8-9403-7142580bf0d7.png)
