### PR TITLE
improve airline#tabline highlighting

### DIFF
--- a/autoload/airline/themes/dracula.vim
+++ b/autoload/airline/themes/dracula.vim
@@ -107,6 +107,21 @@ let g:airline#themes#dracula#palette = {
 \}
 
 " Extensions: {{{
+" Tabline: {{{
+if get(g:, 'airline#extensions#tabline#enabled', 0)
+  let g:airline#themes#dracula#palette.tabline = {
+        \ 'airline_tabfill': s:clr('bg', 'bg'),
+        \
+        \ 'airline_tab': s:clr('comment', 'bg'),
+        \ 'airline_tabsel': s:clr('white', 'bg', 'bold'),
+        \ 'airline_tabmod': s:clr('green', 'bg'),
+        \
+        \ 'airline_tab_right': s:clr('comment', 'bg'),
+        \ 'airline_tabsel_right': s:clr('white', 'bg', 'bold'),
+        \ 'airline_tabmod_right': s:clr('green', 'bg'),
+        \}
+endif
+"}}}
 " CtrlP: {{{2
 if exists('g:loaded_ctrlp')
   let g:airline#themes#dracula#palette.ctrlp = airline#extensions#ctrlp#generate_color_map(


### PR DESCRIPTION
This PR is fairly simple. The additions are just a few small adjustments to the tabline highlighting for airline.

The default tabline highlighting, in my opinion, was both atrocious looking and also somewhat confusing (specifically, it was difficult to easily see what tab was the active tab)

Have a look at this and let me know what you think @benknoble.

One thing to note: I left out `airline_tabtype`, `airline_tabhid`, `airline_tablabel`, and `airline_tabmod_unsel` groups because I couldn't figure out what it was they were for. I played around with them and wasn't able to see any difference. Let me know if there's something I'm missing here and I'll fix those as well.