### PR TITLE
Add 'white' to palette

### DIFF
--- a/autoload/airline/themes/dracula.vim
+++ b/autoload/airline/themes/dracula.vim
@@ -107,6 +107,7 @@ let g:airline#themes#dracula#palette = {
 \}
 
 " Extensions: {{{
+
 " Tabline: {{{
 if get(g:, 'airline#extensions#tabline#enabled', 0)
   let g:airline#themes#dracula#palette.tabline = {
@@ -122,6 +123,7 @@ if get(g:, 'airline#extensions#tabline#enabled', 0)
         \}
 endif
 "}}}
+
 " CtrlP: {{{2
 if exists('g:loaded_ctrlp')
   let g:airline#themes#dracula#palette.ctrlp = airline#extensions#ctrlp#generate_color_map(

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -50,6 +50,7 @@ let s:pink      = ['#FF79C6', 212]
 let s:purple    = ['#BD93F9', 141]
 let s:red       = ['#FF5555', 203]
 let s:yellow    = ['#F1FA8C', 228]
+let s:white     = ['#BFBFBF', 255]
 
 let s:none      = ['NONE', 'NONE']
 
@@ -65,6 +66,7 @@ let g:dracula_palette = {
       \ 'purple': s:purple,
       \ 'red': s:red,
       \ 'yellow': s:yellow,
+      \ 'white': s:white,
       \
       \ 'bglighter': s:bglighter,
       \ 'bglight': s:bglight,


### PR DESCRIPTION
Fix #93 by removing bug from #92, which introduced code using the
'white' section of the palette. This did not exist.

I added it using the ANSI white definition of the spec, and then found
online that the closest 256-color is '255'. Open to change, but looks
very close (if not exact) to the screenshot in #92.


<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->