### PR TITLE
Change specialKey from red to subtle

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -321,7 +321,7 @@ hi! link Type DraculaCyanItalic
 hi! link Delimiter DraculaFg
 
 hi! link Special DraculaPink
-hi! link SpecialKey DraculaRed
+hi! link SpecialKey DraculaSubtle
 hi! link SpecialComment DraculaCyanItalic
 hi! link Tag DraculaCyan
 hi! link helpHyperTextJump DraculaLink


### PR DESCRIPTION
I use listings in vim, so it prints invisible characters. However the tab and the space characters are drawn in red, taking too much attention, so I decided to make them subtle. To activate the listing add this to your .vimrc file:

set listchars=eol:¬,tab:>-,trail:~,extends:>,precedes:<,space:·
set list
So you can see the red is really disguising.


<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->

