### PR TITLE
Remove italics on Ruby constants

### DIFF
--- a/after/syntax/ruby.vim
+++ b/after/syntax/ruby.vim
@@ -14,3 +14,4 @@ hi! link rubyInstanceVariable       DraculaPurpleItalic
 hi! link rubyInterpolationDelimiter DraculaPink
 hi! link rubyRegexpDelimiter        DraculaRed
 hi! link rubyStringDelimiter        DraculaYellow
+hi! link rubyConstant               DraculaPurple


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/6721355/45435011-46335c00-b675-11e8-8ba6-a701d5db2ed1.png)

After:
![image](https://user-images.githubusercontent.com/6721355/45434988-39166d00-b675-11e8-8fae-f328de5860c8.png)
