### PR TITLE
Patch ALE highlights to use dracula colors

### DIFF
--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -36,7 +36,7 @@ endif
 " ALE: {{{
 if exists('g:ale_enabled')
   hi! link ALEError DraculaErrorLine
-  hi! link ALEWarning DraculaWarningLine
+  hi! link ALEWarning DraculaWarnLine
   hi! link ALEInfo DraculaInfoLine
 
   hi! link ALEErrorSign DraculaError

--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -33,4 +33,16 @@ endif
 
 "}}}
 
+" ALE: {{{
+if exists('g:ale_enabled')
+  hi! link ALEError DraculaErrorLine
+  hi! link ALEWarning DraculaWarningLine
+  hi! link ALEInfo DraculaInfoLine
+
+  hi! link ALEErrorSign DraculaError
+  hi! link ALEWarningSign DraculaWarning
+  hi! link ALEInfoSign DraculaInfo
+endif
+" }}}
+
 " vim: fdm=marker ts=2 sts=2 sw=2:

--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -39,9 +39,9 @@ if exists('g:ale_enabled')
   hi! link ALEWarning DraculaWarnLine
   hi! link ALEInfo DraculaInfoLine
 
-  hi! link ALEErrorSign DraculaError
-  hi! link ALEWarningSign DraculaWarning
-  hi! link ALEInfoSign DraculaInfo
+  hi! link ALEErrorSign DraculaRed
+  hi! link ALEWarningSign DraculaOrange
+  hi! link ALEInfoSign DraculaCyan
 endif
 " }}}
 


### PR DESCRIPTION
By default, they are:

- ALEError => SpellBad => DraculaErrorLine
- ALEWarning => SpellCap => DraculaInfoLine
- ALEInfo => ALEWarning => SpellCap => DraculaInfoLine

- ALEErrorSign => Error => DraculaError
- ALEWarningSign => Todo => DraculaTodo
- ALEInfoSign => ALEWarningSign => Todo => DraculaTodo

Proposed change:

- ALEError => DraculaErrorLine
- ALEWarning => DraculaWarningLine
- ALEInfo => DraculaInfoLine

- ALEErrorSign => DraculaError
- ALEWarningSign => DraculaWarning
- ALEInfoSign => DraculaInfo

From discussion in #91 

<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->

