### PR TITLE
Adapt identifier and airline style

### DIFF
--- a/autoload/airline/themes/dracula.vim
+++ b/autoload/airline/themes/dracula.vim
@@ -46,7 +46,7 @@ let g:airline#themes#dracula#palette = {
 \   'normal': s:color_map(
 \       ['bg', 'purple'],
 \       ['fg', 'comment'],
-\       ['fg', 'selection'],
+\       ['fg', 'bg'],
 \       {
 \         'airline_warning': s:clr('bg', 'orange'),
 \         'airline_error': s:clr('bg', 'red'),
@@ -55,12 +55,12 @@ let g:airline#themes#dracula#palette = {
 \   'normal_modified': s:color_map(
 \       ['bg', 'purple'],
 \       ['fg', 'comment'],
-\       ['fg', 'bgdark'],
+\       ['fg', 'bg'],
 \     ),
 \   'insert': s:color_map(
 \       ['bg', 'green'],
 \       ['fg', 'comment'],
-\       ['fg', 'selection'],
+\       ['fg', 'bg'],
 \       {
 \         'airline_warning': s:clr('bg', 'orange'),
 \         'airline_error': s:clr('bg', 'red'),
@@ -69,12 +69,12 @@ let g:airline#themes#dracula#palette = {
 \   'insert_modified': s:color_map(
 \       ['bg', 'green'],
 \       ['fg', 'comment'],
-\       ['fg', 'bgdark'],
+\       ['fg', 'bg'],
 \     ),
 \   'replace': s:color_map(
 \       ['bg', 'orange'],
 \       ['fg', 'comment'],
-\       ['fg', 'selection'],
+\       ['fg', 'bg'],
 \       {
 \         'airline_warning': s:clr('bg', 'orange'),
 \         'airline_error': s:clr('bg', 'red'),
@@ -83,12 +83,12 @@ let g:airline#themes#dracula#palette = {
 \   'replace_modified': s:color_map(
 \       ['bg', 'orange'],
 \       ['fg', 'comment'],
-\       ['fg', 'bgdark'],
+\       ['fg', 'bg'],
 \     ),
 \   'visual': s:color_map(
 \       ['bg', 'yellow'],
 \       ['fg', 'comment'],
-\       ['fg', 'selection'],
+\       ['fg', 'bg'],
 \       {
 \         'airline_warning': s:clr('bg', 'orange'),
 \         'airline_error': s:clr('bg', 'red'),
@@ -97,12 +97,12 @@ let g:airline#themes#dracula#palette = {
 \   'visual_modified': s:color_map(
 \       ['bg', 'yellow'],
 \       ['fg', 'comment'],
-\       ['fg', 'bgdark'],
+\       ['fg', 'bg'],
 \     ),
 \   'inactive': s:color_map(
 \       ['fg', 'selection'],
 \       ['fg', 'selection'],
-\       ['fg', 'selection'],
+\       ['fg', 'bg'],
 \     ),
 \}
 

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -305,7 +305,7 @@ hi! link Number Constant
 hi! link Boolean Constant
 hi! link Float Constant
 
-hi! link Identifier DraculaFg
+hi! link Identifier DraculaOrange
 hi! link Function DraculaGreen
 
 hi! link Statement DraculaPink
@@ -316,7 +316,7 @@ hi! link Operator DraculaPink
 hi! link Keyword DraculaPink
 hi! link Exception DraculaPink
 
-hi! link PreProc DraculaPink
+hi! link PreProc DraculaGreen
 hi! link Include DraculaPink
 hi! link Define DraculaPink
 hi! link Macro DraculaPink


### PR DESCRIPTION
I would like to propose this design change to have a better look and feel in my modest opinion.

You can see in the lower left side of the screenshot that the following changed:
![](https://raw.githubusercontent.com/saschagrunert/dotfiles/master/.github/alacritty.png)

- identifiers are now orange and provide a better visual feedback
- the StatusLine fits into the background and seems less noisy

What do you think about it?