### PR TITLE
Add support for Vim 8 terminal

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -92,6 +92,15 @@ if has('nvim')
   let g:terminal_color_15 = '#FFFFFF'
 endif
 
+if has('terminal')
+  let g:terminal_ansi_colors = [
+      \ '#21222C', '#FF5555', '#50FA7B', '#F1FA8C',
+      \ '#BD93F9', '#FF79C6', '#8BE9FD', '#F8F8F2',
+      \ '#6272A4', '#FF6E6E', '#69FF94', '#FFFFA5',
+      \ '#D6ACFF', '#FF92DF', '#A4FFFF', '#FFFFFF'
+      \]
+endif
+
 " }}}2
 " User Configuration: {{{2
 


### PR DESCRIPTION
Add support for the integrated terminal in Vim 8.

Before:
![Before](https://user-images.githubusercontent.com/94547/54796399-7b24fa80-4c26-11e9-995c-da1610946fbf.jpg)

After:
![After](https://user-images.githubusercontent.com/94547/54796403-7fe9ae80-4c26-11e9-8957-cc314ee3778f.jpg)