### PR TITLE
Terminal commands have bold colors when ctermfg=255 is used in Windows

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -31,7 +31,7 @@ endif
 
 " Palette: {{{2
 
-let s:fg        = ['#F8F8F2', 255]
+let s:fg        = ['#F8F8F2', 253]
 
 let s:bglighter = ['#424450', 238]
 let s:bglight   = ['#343746', 237]


### PR DESCRIPTION
Colors in windows terminal appear bold if 255 or 254 colors are set


![image](https://user-images.githubusercontent.com/370322/57948147-b85be080-7895-11e9-9433-6456750421ce.png)

![image](https://user-images.githubusercontent.com/370322/57948182-cc9fdd80-7895-11e9-9273-f9780cfe3cc3.png)
