### PR TITLE
fix: move back to "typescriptreact" from "typescript.tsx" filetype

### DIFF
--- a/after/syntax/typescript.vim
+++ b/after/syntax/typescript.vim
@@ -1,4 +1,4 @@
-if dracula#should_abort('typescript')
+if dracula#should_abort('typescript', 'typescriptreact')
     finish
 endif
 

--- a/after/syntax/typescript.vim
+++ b/after/syntax/typescript.vim
@@ -2,6 +2,8 @@ if dracula#should_abort('typescript')
     finish
 endif
 
+" HerringtonDarkholme/yats.vim {{{
+
 hi! link typescriptAliasDeclaration       Type
 hi! link typescriptArrayMethod            Function
 hi! link typescriptArrowFunc              Operator
@@ -47,7 +49,9 @@ hi! link typescriptRestOrSpread           Operator
 hi! link typescriptTernaryOp              Operator
 hi! link typescriptTypeAnnotation         Special
 hi! link typescriptTypeCast               Operator
-hi! link typescriptTypeReference          Type
 hi! link typescriptTypeParameter          DraculaOrangeItalic
+hi! link typescriptTypeReference          Type
 hi! link typescriptUnaryOp                Operator
 hi! link typescriptVariable               Keyword
+
+" }}}

--- a/after/syntax/typescriptreact.vim
+++ b/after/syntax/typescriptreact.vim
@@ -1,4 +1,4 @@
-if dracula#should_abort('typescript.tsx')
+if dracula#should_abort('typescriptreact')
     finish
 endif
 


### PR DESCRIPTION
This change is in accordance to the now official filetype defined by vim itself.

See: https://github.com/vim/vim/commit/92852cee3fcff1dc6ce12387b234634e73267b22

<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->