### PR TITLE
Improve inactive airline colors

### DIFF
--- a/autoload/airline/themes/dracula.vim
+++ b/autoload/airline/themes/dracula.vim
@@ -112,8 +112,8 @@ let g:airline#themes#dracula#palette = {
 \       },
 \     ),
 \   'inactive': s:color_map(
-\       ['fg', 'selection'],
-\       ['fg', 'selection'],
+\       ['bg', 'comment'],
+\       ['fg', 'bgdark'],
 \       ['fg', 'selection'],
 \       {
 \         'airline_warning': s:clr('bg', 'orange'),


### PR DESCRIPTION
This is a proposal to improve the styling of an inactive airline.

This is one proposal. I'm open to other colors. The main point that could be improved is that the current colors result in a single background and a single foreground color.

### Before (right)
![69740431-abb81f00-1139-11ea-82a8-d303a4717bee](https://user-images.githubusercontent.com/13085980/69744188-ffc60200-113f-11ea-911d-eaa36e0de6d4.png)


### After
![69741449-57ae3a00-113b-11ea-9a75-cdcb19b41e8d](https://user-images.githubusercontent.com/13085980/69744177-fb014e00-113f-11ea-86cf-dae74317a23b.png)


See <https://github.com/vim-airline/vim-airline-themes/issues/191> for discussion

