### PR TITLE
update lightline's inactive status

### DIFF
--- a/autoload/lightline/colorscheme/dracula.vim
+++ b/autoload/lightline/colorscheme/dracula.vim
@@ -21,7 +21,7 @@ if exists('g:lightline')
   let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
   let s:p.normal.left = [ [ s:black, s:purple ], [ s:cyan, s:gray ] ]
   let s:p.normal.right = [ [ s:black, s:purple ], [ s:white, s:darkblue ] ]
-  let s:p.inactive.right = [ [ s:black, s:gray ], [ s:white, s:black ] ]
+  let s:p.inactive.right = [ [ s:black, s:darkblue ], [ s:white, s:black ] ]
   let s:p.inactive.left =  [ [ s:cyan, s:black ], [ s:white, s:black ] ]
   let s:p.insert.left = [ [ s:black, s:green ], [ s:cyan, s:gray ] ]
   let s:p.replace.left = [ [ s:black, s:red ], [ s:cyan, s:gray ] ]


### PR DESCRIPTION
<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->
Hi!

This Pull Request is to resolve issue number #156 

If we adopt new vim-airline's colorscheme, we should adjust lightline's too.

Please review this pull request.

## screenshot

### before

<img width="706" alt="スクリーンショット 2019-12-03 10 25 00" src="https://user-images.githubusercontent.com/36619465/70015869-0d590d00-15c2-11ea-94d9-9b1f6f6dda81.png">

### after
<img width="705" alt="スクリーンショット 2019-12-03 10 24 39" src="https://user-images.githubusercontent.com/36619465/70015884-177b0b80-15c2-11ea-939b-8eba36abded5.png">


