### PR TITLE
Set colors for syntax defined by stephpy/vim-yaml.

### DIFF
--- a/after/syntax/yaml.vim
+++ b/after/syntax/yaml.vim
@@ -10,7 +10,7 @@ hi! link yamlFlowIndicator   Delimiter
 hi! link yamlNodeTag         DraculaPink
 hi! link yamlPlainScalar     DraculaYellow
 
-" Links for stephpy/yaml
+" stephpy/yaml {{{
 
 " yamlConstant
 hi! link Keyword DraculaPurple
@@ -31,3 +31,5 @@ hi! link Operator Delimiter
 hi! link String DraculaYellow
 " yamlEscape
 hi! link Special DraculaPink
+
+" }}}

--- a/after/syntax/yaml.vim
+++ b/after/syntax/yaml.vim
@@ -10,3 +10,24 @@ hi! link yamlFlowIndicator   Delimiter
 hi! link yamlNodeTag         DraculaPink
 hi! link yamlPlainScalar     DraculaYellow
 
+" Links for stephpy/yaml
+
+" yamlConstant
+hi! link Keyword DraculaPurple
+" yamlIndicator
+hi! link PreCondit DraculaPink
+" yamlAnchor, yamlAlias
+hi! link Function DraculaPinkItalic
+" yamlKey
+hi! link Identifier DraculaCyan
+" yamlType
+hi! link Type DraculaPink
+
+" yamlComment
+hi! link Comment DraculaComment
+" yamlInline, yamlBlock
+hi! link Operator Delimiter
+" yamlString
+hi! link String DraculaYellow
+" yamlEscape
+hi! link Special DraculaPink


### PR DESCRIPTION
<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->

An attempt to fix Dracula colors when using [stephpy/vim-yaml](https://github.com/stephpy/vim-yaml) syntax definitions. Result is not perfect, as the syntax file does not match a lot of things. Screenshots attached:

Dracula with default vim syntax for YAML:
![default_vim](https://user-images.githubusercontent.com/2626117/71328278-07957e00-2515-11ea-91a3-d246002bdfd3.png)

Dracula with stephpy/vim-yaml before the fix:
![stephpy_before](https://user-images.githubusercontent.com/2626117/71328311-825e9900-2515-11ea-8765-4c662f7ddf12.png)

Dracula with stephpy/vim-yaml after the fix:
![stephpy_after](https://user-images.githubusercontent.com/2626117/71328293-41668480-2515-11ea-801c-461ae3e4c282.png)

The default vim syntax seems superior, but stephpy/vim-yaml plugin is widely used, e.g. in [sheerun/vim-polyglot](https://github.com/sheerun/vim-polyglot). So, the fix might still be useful.