### PR TITLE
Update instructions for newbie users like me

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,42 @@
 ### [Vim](http://www.vim.org/)
 
-#### Install using Git
+#### Install
+
+These are the default instructions using Vim 8's `|packages|` feature. See sections below, if you use other plugin managers.
+
+1. Create theme folder (in case you don't have yet):
+
+	```
+mkdir -p ~/.vim/pack/themes/start
+	```
+
+2. Navigate to the folder above:
+
+	```
+cd ~/.vim/pack/themes/start
+	```
+
+3. Clone the repository using the "dracula" name:
+
+    ```
+git clone https://github.com/dracula/vim.git dracula
+	```
+
+4. Create configuration file (in case you don't have yet):
+
+	```
+touch ~/.vimrc
+	```
+
+5. Edit the `~/.vimrc` file with the following content:
+
+	```
+packadd! dracula
+syntax on
+colorscheme dracula
+	```
+
+#### Install using other plugin managers
 
 If you [use vim + pathogen](http://vimcasts.org/episodes/synchronizing-plugins-with-git-submodules-and-pathogen/):
 
@@ -18,9 +54,3 @@ If you [use vim-plug](https://github.com/junegunn/vim-plug) (\`as\` will install
     :PlugInstall
 
 Note that dracula must be in your `'runtimepath'` to load properly: Version 2.0 introduced autoload functionality for part of the plugin, which doesn't work without `'runtimepath'` properly set.
-
-For users of Vim 8's `|packages|` feature, it suffices to put
-
-    packadd! dracula
-
-in your vimrc, alongside `syntax on` and `colorscheme dracula`. For users of other plugin managers, consult your documentation to make sure you put dracula on the `'runtimepath'` before loading it.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,4 +53,4 @@ If you [use vim-plug](https://github.com/junegunn/vim-plug) (\`as\` will install
     Plug 'dracula/vim', { 'as': 'dracula' }
     :PlugInstall
 
-Note that dracula must be in your `'runtimepath'` to load properly: Version 2.0 introduced autoload functionality for part of the plugin, which doesn't work without `'runtimepath'` properly set.
+Note that dracula must be in your `'runtimepath'` to load properly: Version 2.0 introduced autoload functionality for part of the plugin, which doesn't work without `'runtimepath'` properly set. Consult your plugin-managers documentation to make sure you put dracula on the `'runtimepath'` before loading it.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,39 +2,40 @@
 
 #### Install
 
-These are the default instructions using Vim 8's `|packages|` feature. See sections below, if you use other plugin managers.
+These are the default instructions using Vim 8's `|packages|` feature. See
+sections below, if you use other plugin managers.
 
 1. Create theme folder (in case you don't have yet):
 
-	```
+```
 mkdir -p ~/.vim/pack/themes/start
-	```
+```
 
 2. Navigate to the folder above:
 
-	```
+```
 cd ~/.vim/pack/themes/start
-	```
+```
 
 3. Clone the repository using the "dracula" name:
 
-    ```
+```
 git clone https://github.com/dracula/vim.git dracula
-	```
+```
 
 4. Create configuration file (in case you don't have yet):
 
-	```
+```
 touch ~/.vimrc
-	```
+```
 
 5. Edit the `~/.vimrc` file with the following content:
 
-	```
+```
 packadd! dracula
-syntax on
+syntax enable
 colorscheme dracula
-	```
+```
 
 #### Install using other plugin managers
 
@@ -43,14 +44,26 @@ If you [use vim + pathogen](http://vimcasts.org/episodes/synchronizing-plugins-w
     cd ~/.vim
     git submodule add git@github.com:dracula/vim.git bundle/dracula
 
-If you [use vim + vundle](https://github.com/gmarik/vundle):
+Place `colorscheme dracula` after `execute pathogen#infect()`.
+
+If you [use vim + vundle](https://github.com/VundleVim/Vundle):
 
     Plugin 'dracula/vim', { 'name': 'dracula' }
     :PluginInstall
 
-If you [use vim-plug](https://github.com/junegunn/vim-plug) (\`as\` will install the plugin in a directory called 'dracula' instead of just 'vim'):
+Place `colorscheme dracula` after `call vundle#end()`.
+
+If you [use vim-plug](https://github.com/junegunn/vim-plug) (\`as\` will install
+the plugin in a directory called 'dracula' instead of just 'vim'):
 
     Plug 'dracula/vim', { 'as': 'dracula' }
     :PlugInstall
 
-Note that dracula must be in your `'runtimepath'` to load properly: Version 2.0 introduced autoload functionality for part of the plugin, which doesn't work without `'runtimepath'` properly set. Consult your plugin-managers documentation to make sure you put dracula on the `'runtimepath'` before loading it.
+Place `colorscheme dracula` after `call plug#end()`.
+
+---
+
+Note that dracula must be in your `'runtimepath'` to load properly: Version 2.0
+introduced autoload functionality for part of the plugin, which doesn't work
+without `'runtimepath'` properly set. Consult your plugin-managers documentation
+to make sure you put dracula on the `'runtimepath'` before loading it.

--- a/README.md
+++ b/README.md
@@ -6,24 +6,7 @@
 
 ## Install
 
-All instructions can be found at
-[draculatheme.com/vim](https://draculatheme.com/vim).
-
-Note that dracula must be in your `'runtimepath'` to load properly: Version 2.0
-introduced autoload functionality for part of the plugin, which doesn't work
-without `'runtimepath'` properly set.
-
-For users of Vim 8's `|packages|` feature, it suffices to put
-
-    packadd! {name}
-    colorscheme dracula
-
-in your vimrc. `{name}` Should be replaced by the directory you put the code in.
-For example, if you use `~/.vim/pack/themes/start/my-dracula-theme`, you would do
-`packadd! my-dracula-theme`.
-
-For users of other plugin managers, consult your documentation
-to make sure you put dracula on the `'runtimepath'` before loading it.
+All instructions can be found at [draculatheme.com/vim](https://draculatheme.com/vim).
 
 ## Team
 


### PR DESCRIPTION
Hey @benknoble @dsifford,

I never used Vim and today I tried to install the theme. My goal was to use Dracula on MacVim and also on my terminal. Since I'm not used to it, I must admit I had some trouble to configure it. This issue https://github.com/dracula/vim/issues/157 is what helped me to enable it. That's why I'm sending this PR - it's an attempt to facilitate the instructions for other people.

Once again, I'm not an expert, so feel free to request changes.

> Note: In order to make it work on my terminal, I also had to add these files to my `~/.vimrc` file. I'm not sure if we should add them in the instructions too or if I missed something.

```
set t_Co=256
set term=xterm
set background=dark
```

### Machine Info

<!--
if on a *nix system, please provide the output of `uname -a` for OS field
-->
- **Vim type** vim and MacVim
- **Vim version**: 8.1.1312
- **OS**: Darwin 19.3.0 Darwin Kernel Version 19.3.0: Thu Jan  9 20:58:23 PST 2020; root:xnu-6153.81.5~1/RELEASE_X86_64 x86_64
- **Terminal/Terminal Emulator/VTE**: iTerm, Hyper and Mac Terminal
- **`TERM` environment variable**: xterm-256color
