### PR TITLE
Neovim : add lsp message hightlighting

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -250,6 +250,15 @@ call s:h('Conceal', s:cyan, s:none)
 " Neovim uses SpecialKey for escape characters only. Vim uses it for that, plus whitespace.
 if has('nvim')
   hi! link SpecialKey DraculaRed
+  hi! link LspDiagnosticsUnderline DraculaFgUnderline
+  hi! link LspDiagnosticsInformation DraculaCyan
+  hi! link LspDiagnosticsHint DraculaCyan
+  hi! link LspDiagnosticsError DraculaError
+  hi! link LspDiagnosticsWarning DraculaOrange
+  hi! link LspDiagnosticsUnderlineError DraculaErrorLine
+  hi! link LspDiagnosticsUnderlineHint DraculaInfoLine
+  hi! link LspDiagnosticsUnderlineInformation DraculaInfoLine
+  hi! link LspDiagnosticsUnderlineWarning DraculaWarnLine
 else
   hi! link SpecialKey DraculaSubtle
 endif
@@ -305,4 +314,4 @@ hi! link helpBacktick Special
 
 "}}}
 
-" vim: fdm=marker ts=2 sts=2 sw=2 fdl=0:
+" vim: fdm=marker ts=2 sts=2 sw=2 fdl=0 et:


### PR DESCRIPTION
Neovim now supports LSP protocol, and this commit adds highlighting for
it.

Below is an example of what changes on Rust code using `rls`.
Before :
![Capture d’écran 2020-03-03 à 09 29 48](https://user-images.githubusercontent.com/39092278/75756918-b9c99d00-5d31-11ea-968b-d967538f3cb5.png)

After :
![Capture d’écran 2020-03-03 à 09 30 23](https://user-images.githubusercontent.com/39092278/75756956-c77f2280-5d31-11ea-8229-c4136b9d1291.png)