### PR TITLE
[update] airline's terminal section color

### DIFF
--- a/autoload/airline/themes/dracula.vim
+++ b/autoload/airline/themes/dracula.vim
@@ -121,7 +121,7 @@ let g:airline#themes#dracula#palette = {
 \       },
 \     ),
 \   'terminal': s:color_map(
-\       ['bg', 'purple'],
+\       ['bg', 'green'],
 \       ['fg', 'comment'],
 \       ['fg', 'selection'],
 \       {


### PR DESCRIPTION
<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->

I've updated the color scheme in the terminal section of the vim-airline.
This is expected to improve the user interface.
This uses the same green color scheme as the insert mode color scheme.

## screenshot

### before

![before](https://user-images.githubusercontent.com/36619465/85307192-8da57800-b4ea-11ea-8605-1609703719e6.gif)

### after

![after](https://user-images.githubusercontent.com/36619465/85307227-99913a00-b4ea-11ea-8edb-e75fdba1a510.gif)


