### PR TITLE
JSX - Support vim-jsx-pretty and improve YATS syntax

### DIFF
--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -1,4 +1,4 @@
-if dracula#should_abort('javascript', 'javascriptreact', 'javascript.jsx') 
+if dracula#should_abort('javascript', 'javascriptreact', 'javascript.jsx')
   finish
 endif
 
@@ -19,8 +19,6 @@ hi! link jsDocTypeBrackets         DraculaCyan
 hi! link jsFuncArgOperator         Operator
 hi! link jsFunction                Keyword
 hi! link jsTemplateBraces          Special
-hi! link jsModuleAsterisk          DraculaPurpleItalic
-hi! link jsVariableDef             DraculaPurple
 
 "}}}
 

--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -20,6 +20,7 @@ hi! link jsFuncArgOperator         Operator
 hi! link jsFunction                Keyword
 hi! link jsTemplateBraces          Special
 hi! link jsModuleAsterisk          DraculaPurpleItalic
+hi! link jsVariableDef             DraculaPurple
 
 "}}}
 

--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -1,5 +1,5 @@
-if dracula#should_abort('javascript')
-    finish
+if dracula#should_abort('javascript', 'javascript.jsx') 
+  finish
 endif
 
 hi! link javaScriptBraces   Delimiter
@@ -19,7 +19,14 @@ hi! link jsDocTypeBrackets         DraculaCyan
 hi! link jsFuncArgOperator         Operator
 hi! link jsFunction                Keyword
 hi! link jsTemplateBraces          Special
+hi! link jsModuleAsterisk          DraculaPurpleItalic
 
 "}}}
+
+" maxmellon/vim-jsx-pretty 
+
+hi! link jsxComponentName   Type
+hi! link jsxAttrib          DraculaGreenItalic
+hi! link jsxCloseString     DraculaFg
 
 " vim: fdm=marker ts=2 sts=2 sw=2 fdl=0:

--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -24,10 +24,13 @@ hi! link jsTemplateBraces          Special
 
 " maxmellon/vim-jsx-pretty {{{
 
-hi! link jsxTagName         Function
-hi! link jsxCloseTag        DraculaPurple
-hi! link jsxCloseString     Comment
-hi! link jsxOpenPunct       Comment
+hi! link jsxTag             Keyword
+hi! link jsxTagName         Keyword
+hi! link jsxComponentName   Type
+hi! link jsxCloseTag        Type
+hi! link jsxAttrib          DraculaGreenItalic
+hi! link jsxCloseString     Identifier
+hi! link jsxOpenPunct       Identifier
 
 " }}}
 

--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -1,4 +1,4 @@
-if dracula#should_abort('javascript', 'javascript.jsx') 
+if dracula#should_abort('javascript', 'javascriptreact', 'javascript.jsx') 
   finish
 endif
 
@@ -24,10 +24,13 @@ hi! link jsVariableDef             DraculaPurple
 
 "}}}
 
-" maxmellon/vim-jsx-pretty 
+" maxmellon/vim-jsx-pretty {{{
 
-hi! link jsxComponentName   Type
-hi! link jsxAttrib          DraculaGreenItalic
-hi! link jsxCloseString     DraculaFg
+hi! link jsxTagName         Function
+hi! link jsxCloseTag        DraculaPurple
+hi! link jsxCloseString     Comment
+hi! link jsxOpenPunct       Comment
+
+" }}}
 
 " vim: fdm=marker ts=2 sts=2 sw=2 fdl=0:

--- a/after/syntax/javascriptreact.vim
+++ b/after/syntax/javascriptreact.vim
@@ -1,0 +1,1 @@
+runtime! syntax/javascript.vim

--- a/after/syntax/typescript.vim
+++ b/after/syntax/typescript.vim
@@ -1,4 +1,4 @@
-if dracula#should_abort('typescript', 'typescriptreact')
+if dracula#should_abort('typescript', 'typescriptreact', 'typescript.tsx')
     finish
 endif
 

--- a/after/syntax/typescriptreact.vim
+++ b/after/syntax/typescriptreact.vim
@@ -8,3 +8,15 @@ hi! link tsxAttrib           DraculaGreenItalic
 hi! link tsxEqual            Operator
 hi! link tsxIntrinsicTagName Keyword
 hi! link tsxTagName          Type
+
+" maxmellon/vim-jsx-pretty {{{
+
+hi! link jsxTag             Keyword
+hi! link jsxTagName         Keyword
+hi! link jsxComponentName   Type
+hi! link jsxCloseTag        Type
+hi! link jsxAttrib          DraculaGreenItalic
+hi! link jsxCloseString     Identifier
+hi! link jsxOpenPunct       Identifier
+
+" }}}

--- a/after/syntax/typescriptreact.vim
+++ b/after/syntax/typescriptreact.vim
@@ -1,10 +1,27 @@
-if dracula#should_abort('typescriptreact')
+if dracula#should_abort('typescriptreact', 'typescript.tsx')
     finish
 endif
 
 runtime! syntax/typescript.vim
 
-hi! link tsxAttrib           DraculaGreenItalic
-hi! link tsxEqual            Operator
-hi! link tsxIntrinsicTagName Keyword
-hi! link tsxTagName          Type
+" HerringtonDarkholme/yats.vim {{{
+
+hi! link tsxTag                Comment
+hi! link tsxCloseTag           Comment
+hi! link tsxCloseString        Comment
+hi! link tsxIntrinsicTagName   Function
+hi! link tsxTagName            Function
+hi! link tsxFragment           Function
+hi! link tsxAttrib             Type
+hi! link tsxEqual              Operator
+
+" }}}
+
+" maxmellon/vim-jsx-pretty {{{
+
+hi! link jsxTagName         Function
+hi! link jsxCloseTag        DraculaPurple
+hi! link jsxCloseString     Comment
+hi! link jsxOpenPunct       Comment
+
+" }}}

--- a/after/syntax/typescriptreact.vim
+++ b/after/syntax/typescriptreact.vim
@@ -1,27 +1,10 @@
-if dracula#should_abort('typescriptreact', 'typescript.tsx')
+if dracula#should_abort('typescriptreact')
     finish
 endif
 
 runtime! syntax/typescript.vim
 
-" HerringtonDarkholme/yats.vim {{{
-
-hi! link tsxTag                Comment
-hi! link tsxCloseTag           Comment
-hi! link tsxCloseString        Comment
-hi! link tsxIntrinsicTagName   Function
-hi! link tsxTagName            Function
-hi! link tsxFragment           Function
-hi! link tsxAttrib             Type
-hi! link tsxEqual              Operator
-
-" }}}
-
-" maxmellon/vim-jsx-pretty {{{
-
-hi! link jsxTagName         Function
-hi! link jsxCloseTag        DraculaPurple
-hi! link jsxCloseString     Comment
-hi! link jsxOpenPunct       Comment
-
-" }}}
+hi! link tsxAttrib           DraculaGreenItalic
+hi! link tsxEqual            Operator
+hi! link tsxIntrinsicTagName Keyword
+hi! link tsxTagName          Type


### PR DESCRIPTION
Closes #193 

#### SCREENSHOTS 

_vim-jsx-pretty default_

<img width="519" alt="Screen Shot 2020-07-05 at 14 28 39" src="https://user-images.githubusercontent.com/1663717/86538370-1a2d3e80-becc-11ea-9394-766f53b546c3.png">

_with vim-jsx-pretty highlight close tag_

<img width="500" alt="Screen Shot 2020-07-05 at 14 28 18" src="https://user-images.githubusercontent.com/1663717/86538376-24e7d380-becc-11ea-90c0-af5991204b76.png">

**EDIT**: Updated images matching correct colors.