### PR TITLE
Add RST syntax colors

### DIFF
--- a/after/syntax/lua.vim
+++ b/after/syntax/lua.vim
@@ -4,3 +4,19 @@ endif
 
 hi! link luaFunc  DraculaCyan
 hi! link luaTable DraculaFg
+
+" tbastos/vim-lua {{{
+
+hi! link luaBraces       DraculaFg
+hi! link luaBuiltIn      Constant
+hi! link luaDocTag       Keyword
+hi! link luaErrHand      DraculaCyan
+hi! link luaFuncArgName  DraculaOrangeItalic
+hi! link luaFuncCall     Function
+hi! link luaLocal        Keyword
+hi! link luaSpecialTable Constant
+hi! link luaSpecialValue DraculaCyan
+
+" }}}
+
+" vim: fdm=marker ts=2 sts=2 sw=2 fdl=0:

--- a/after/syntax/rst.vim
+++ b/after/syntax/rst.vim
@@ -1,0 +1,26 @@
+if dracula#should_abort('rst')
+    finish
+endif
+
+hi! link rstComment                             DraculaComment
+hi! link rstCitationReference                   DraculaCyan
+hi! link rstFootnoteReference                   DraculaCyan
+hi! link rstHyperLinkReference                  DraculaCyan
+hi! link rstHyperlinkTarget                     DraculaCyan
+hi! link rstInlineInternalTargets               DraculaCyan
+hi! link rstInterpretedTextOrHyperlinkReference DraculaCyan
+hi! link rstCodeBlock                           DraculaGreen
+hi! link rstInlineLiteral                       DraculaGreen
+hi! link rstLiteralBlock                        DraculaGreen
+hi! link rstQuotedLiteralBlock                  DraculaGreen
+hi! link rstStandaloneHyperlink                 DraculaLink
+hi! link rstStrongEmphasis                      DraculaOrangeBold
+hi! link rstDirective                           DraculaPink
+hi! link rstSubstitutionDefinition              DraculaPink
+hi! link rstSections                            DraculaPurpleBold
+hi! link rstTransition                          DraculaPurpleBold
+hi! link rstTodo                                DraculaTodo
+hi! link rstCitation                            DraculaYellow
+hi! link rstExDirective                         DraculaYellow
+hi! link rstFootnote                            DraculaYellow
+hi! link rstEmphasis                            DraculaYellowItalic

--- a/after/syntax/rst.vim
+++ b/after/syntax/rst.vim
@@ -2,25 +2,25 @@ if dracula#should_abort('rst')
     finish
 endif
 
-hi! link rstComment                             DraculaComment
-hi! link rstCitationReference                   DraculaCyan
-hi! link rstFootnoteReference                   DraculaCyan
-hi! link rstHyperLinkReference                  DraculaCyan
-hi! link rstHyperlinkTarget                     DraculaCyan
-hi! link rstInlineInternalTargets               DraculaCyan
-hi! link rstInterpretedTextOrHyperlinkReference DraculaCyan
+hi! link rstComment                             Comment
+hi! link rstTransition                          Comment
 hi! link rstCodeBlock                           DraculaGreen
 hi! link rstInlineLiteral                       DraculaGreen
 hi! link rstLiteralBlock                        DraculaGreen
 hi! link rstQuotedLiteralBlock                  DraculaGreen
 hi! link rstStandaloneHyperlink                 DraculaLink
 hi! link rstStrongEmphasis                      DraculaOrangeBold
-hi! link rstDirective                           DraculaPink
-hi! link rstSubstitutionDefinition              DraculaPink
 hi! link rstSections                            DraculaPurpleBold
-hi! link rstTransition                          DraculaPurpleBold
-hi! link rstTodo                                DraculaTodo
-hi! link rstCitation                            DraculaYellow
-hi! link rstExDirective                         DraculaYellow
-hi! link rstFootnote                            DraculaYellow
 hi! link rstEmphasis                            DraculaYellowItalic
+hi! link rstDirective                           Keyword
+hi! link rstSubstitutionDefinition              Keyword
+hi! link rstCitation                            String
+hi! link rstExDirective                         String
+hi! link rstFootnote                            String
+hi! link rstCitationReference                   Tag
+hi! link rstFootnoteReference                   Tag
+hi! link rstHyperLinkReference                  Tag
+hi! link rstHyperlinkTarget                     Tag
+hi! link rstInlineInternalTargets               Tag
+hi! link rstInterpretedTextOrHyperlinkReference Tag
+hi! link rstTodo                                Todo


### PR DESCRIPTION
First PR, feedback and comment are welcomed. Thanks a lot!

- Add Dracula RST syntax colors to approximate Dracula Markdown syntax colors. RST is the other popular documentation format. Dracula RST colors is a nice feature to have when editing documentation between different projects. 
- Fix undefined `g:dracula_undercurl` when user disables underline. Current workaround requires the user to also disable undercurl when disabling underline. The fix is minor, but improves UX with least surprise.