### PR TITLE
Fix E121: Undefined variable `g:dracula_undercurl`

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -82,11 +82,7 @@ if !exists('g:dracula_underline')
 endif
 
 if !exists('g:dracula_undercurl')
-  if g:dracula_underline == 0
-    let g:dracula_undercurl = 0
-  else
-    let g:dracula_undercurl = 1
-  endif
+  let g:dracula_undercurl = g:dracula_underline
 endif
 
 if !exists('g:dracula_inverse')

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -81,8 +81,12 @@ if !exists('g:dracula_underline')
   let g:dracula_underline = 1
 endif
 
-if !exists('g:dracula_undercurl') && g:dracula_underline != 0
-  let g:dracula_undercurl = 1
+if !exists('g:dracula_undercurl')
+  if g:dracula_underline == 0
+    let g:dracula_undercurl = 0
+  else
+    let g:dracula_undercurl = 1
+  endif
 endif
 
 if !exists('g:dracula_inverse')


### PR DESCRIPTION
The variable `g:dracula_undercurl` is not properly defined
when underline attribute is disabled by user configuration:

    let g:dracula_underline = 0

The fix always defines missing `g:dracula_undercurl`,
but also disables it when underline is disabled.


