### PR TITLE
add highlights for tbastos/vim-lua

### DIFF
--- a/after/syntax/lua.vim
+++ b/after/syntax/lua.vim
@@ -8,7 +8,7 @@ hi! link luaTable DraculaFg
 " tbastos/vim-lua {{{
 
 hi! link luaBraces       DraculaFg
-hi! link luaBuiltIn      DraculaPurpleItalic
+hi! link luaBuiltIn      Constant
 hi! link luaDocTag       Keyword
 hi! link luaErrHand      DraculaCyan
 hi! link luaFuncArgName  DraculaOrangeItalic

--- a/after/syntax/lua.vim
+++ b/after/syntax/lua.vim
@@ -14,7 +14,7 @@ hi! link luaErrHand      DraculaCyan
 hi! link luaFuncArgName  DraculaOrangeItalic
 hi! link luaFuncCall     Function
 hi! link luaLocal        Keyword
-hi! link luaSpecialTable DraculaPurple
+hi! link luaSpecialTable Constant
 hi! link luaSpecialValue DraculaCyan
 
 " }}}

--- a/after/syntax/lua.vim
+++ b/after/syntax/lua.vim
@@ -4,3 +4,19 @@ endif
 
 hi! link luaFunc  DraculaCyan
 hi! link luaTable DraculaFg
+
+" tbastos/vim-lua {{{
+
+hi! link luaBraces       DraculaFg
+hi! link luaBuiltIn      DraculaPurpleItalic
+hi! link luaDocTag       Keyword
+hi! link luaFuncArgName  DraculaOrangeItalic
+hi! link luaFuncCall     Function
+hi! link luaFuncKeyword  Keyword
+hi! link luaLocal        Keyword
+hi! link luaSpecialTable DraculaPurple
+hi! link luaSpecialValue DraculaCyan
+
+" }}}
+
+" vim: fdm=marker ts=2 sts=2 sw=2 fdl=0:

--- a/after/syntax/lua.vim
+++ b/after/syntax/lua.vim
@@ -13,7 +13,6 @@ hi! link luaDocTag       Keyword
 hi! link luaErrHand      DraculaCyan
 hi! link luaFuncArgName  DraculaOrangeItalic
 hi! link luaFuncCall     Function
-hi! link luaFuncKeyword  Keyword
 hi! link luaLocal        Keyword
 hi! link luaSpecialTable DraculaPurple
 hi! link luaSpecialValue DraculaCyan

--- a/after/syntax/lua.vim
+++ b/after/syntax/lua.vim
@@ -10,6 +10,7 @@ hi! link luaTable DraculaFg
 hi! link luaBraces       DraculaFg
 hi! link luaBuiltIn      DraculaPurpleItalic
 hi! link luaDocTag       Keyword
+hi! link luaErrHand      DraculaCyan
 hi! link luaFuncArgName  DraculaOrangeItalic
 hi! link luaFuncCall     Function
 hi! link luaFuncKeyword  Keyword


### PR DESCRIPTION
Hello!

The default Vim syntax file for Lua is somewhat lacking, so I added some highlights for [tbastos/vim-lua](https://github.com/tbastos/vim-lua) (which is bundled with [vim-polyglot](https://github.com/sheerun/vim-polyglot/)

I tried mapping the highlight groups in accordance with the [spec](https://spec.draculatheme.com/):

- `luaBraces` -> `BracketsParensBraces`
- `luaBuiltIn` -> `InstanceReservedWords`
- `luaDocTag` -> `DocCommentKeywords`
- `luaErrHand` -> `BuiltInFunctions`
- `luaFuncArgName` -> `FunctionParameters`
- `luaFuncCall` -> `FunctionNames`
- `luaLocal` -> `Keyword`
- `luaSpecialTable` -> `BuiltInMagicMethodsOrConstants`
- `luaSpecialValue` -> `BuiltInFunctions`

Here's how it looks compared to the reference implementation:

![screenshots](https://user-images.githubusercontent.com/56110730/97791041-7f6d1400-1bce-11eb-9341-7a5d402d1048.png)

Thanks for maintaining `dracula/vim`!