### PR TITLE
Add RST syntax to mimic Markdown colors

### DIFF
--- a/after/syntax/rst.vim
+++ b/after/syntax/rst.vim
@@ -1,0 +1,26 @@
+if dracula#should_abort('rst')
+    finish
+endif
+
+hi! link rstComment                             Comment
+hi! link rstTransition                          Comment
+hi! link rstCodeBlock                           DraculaGreen
+hi! link rstInlineLiteral                       DraculaGreen
+hi! link rstLiteralBlock                        DraculaGreen
+hi! link rstQuotedLiteralBlock                  DraculaGreen
+hi! link rstStandaloneHyperlink                 DraculaLink
+hi! link rstStrongEmphasis                      DraculaOrangeBold
+hi! link rstSections                            DraculaPurpleBold
+hi! link rstEmphasis                            DraculaYellowItalic
+hi! link rstDirective                           Keyword
+hi! link rstSubstitutionDefinition              Keyword
+hi! link rstCitation                            String
+hi! link rstExDirective                         String
+hi! link rstFootnote                            String
+hi! link rstCitationReference                   Tag
+hi! link rstFootnoteReference                   Tag
+hi! link rstHyperLinkReference                  Tag
+hi! link rstHyperlinkTarget                     Tag
+hi! link rstInlineInternalTargets               Tag
+hi! link rstInterpretedTextOrHyperlinkReference Tag
+hi! link rstTodo                                Todo


### PR DESCRIPTION
Hi Dracula Vim,

Second PR to add RST syntax color, hopefully without branch corruption!

Markdown and RST are popular formats for documentation. Alas, current RST file does not look as nice as Markdown file. This proposal remaps RST colors to be more consistent with Markdown [spec](https://spec.draculatheme.com/#sec-Markup-Markdown-RST-etc-).

Most noticeable RST improvements are: purple Headings, cyan Links and green TextBlocks. Most noticeable RST divergences are: Footnote and Citation text, no highlight group for List Marker, and language highlight in code block extension.

See attached image for comparison. The leftmost pane shows Markdown syntax as reference; the center pane shows the current RST syntax; the rightmost pane shows the proposed RST syntax.
![test_rst](https://user-images.githubusercontent.com/62191526/98070012-47fca280-1e2e-11eb-8da6-fe44e80edd0e.png)

Thanks a lot!