### PR TITLE
Syntax Highlighting specific for PureScript

### DIFF
--- a/after/syntax/purescript.vim
+++ b/after/syntax/purescript.vim
@@ -1,0 +1,9 @@
+if dracula#should_abort('purescript')
+    finish
+endif
+
+hi! link purescriptModule Type
+hi! link purescriptImport DraculaCyan
+hi! link purescriptImportAs DraculaCyan
+hi! link purescriptOperator Operator
+hi! link purescriptBacktick Operator


### PR DESCRIPTION
I started adding specific syntax for PureScript.

The intention was to avoid having the same color in the module and import line. The change for operator/backtick doesn't actually change the color, but is semantically right.

## Syntax Variables

The names are taken from [gruvbox](https://github.com/morhetz/gruvbox/blob/040138616bec342d5ea94d4db296f8ddca17007a/colors/gruvbox.vim#L1218-L1233
).

### Used

* purescriptModuleKeyword
* purescriptImportKeyword
* purescriptHidingKeyword
* purescriptAsKeyword
* purescriptOperator
* purescriptBacktick

### Unused

* purescriptStructure
* purescriptModuleName
* purescriptWhere
* purescriptDelimiter
* purescriptType
* purescriptTypeVar
* purescriptConstructor
* purescriptFunction
* purescriptConditional

## Screenshot


![image](https://user-images.githubusercontent.com/13085980/101079498-da1bd600-35a7-11eb-9e31-b081b67d61ce.png)


