### PR TITLE
Add hightlight groups for nvim-treesitter

### DIFF
--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -54,20 +54,20 @@ if exists('g:loaded_nvim_treesitter')
   hi! link TSConstMacro DraculaCyan
   hi! link TSStringRegex DraculaYellow
   hi! link TSString DraculaYellow
-  hi! link TSStringEscape DraculaCyan
+  hi! link TSStringEscape DraculaPink
   hi! link TSSymbol DraculaPurple
   hi! link TSCharacter DraculaGreen
   hi! link TSNumber DraculaPurple
   hi! link TSBoolean DraculaPurple
   hi! link TSFloat DraculaPurple
   hi! link TSAnnotation DraculaYellow
-  hi! link TSAttribute DraculaCyan
+  hi! link TSAttribute DraculaGreenItalic
   hi! link TSNamespace DraculaPink
   " # Functions
   hi! link TSFuncBuiltin DraculaCyan
   hi! link TSFunction DraculaGreen
   hi! link TSFuncMacro DraculaGreen
-  hi! link TSParameter DraculaOrange
+  hi! link TSParameter DraculaOrangeItalic
   hi! link TSParameterReference DraculaOrange
   hi! link TSMethod DraculaGreen
   hi! link TSField DraculaOrange
@@ -88,12 +88,12 @@ if exists('g:loaded_nvim_treesitter')
   hi! link TSInclude DraculaPink
   " # Variable
   hi! link TSVariable Normal
-  hi! link TSVariableBuiltin DraculaPurple
+  hi! link TSVariableBuiltin DraculaPurpleItalic
   " # Text
-  hi! link TSText DraculaYellow
-  hi! link TSStrong DraculaYellowBold
-  hi! link TSEmphasis DraculaYellowItalic
-  hi! link TSUnderline DraculaYellowUnderline
+  hi! link TSText DraculaFg
+  hi! link TSStrong DraculaFg
+  hi! link TSEmphasis DraculaFg
+  hi! link TSUnderline DraculaFg
   hi! link TSTitle DraculaYellow
   hi! link TSLiteral DraculaYellow
   hi! link TSURI DraculaYellow

--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -79,7 +79,7 @@ if exists('g:loaded_nvim_treesitter')
   hi! link TSLabel DraculaPurpleItalic
   hi! link TSKeyword Keyword
   hi! link TSKeywordFunction DraculaCyan
-  hi! link TSKeywordOperator DraculaPink
+  hi! link TSKeywordOperator Operator
   hi! link TSOperator Operator
   hi! link TSException DraculaPurple
   hi! link TSType Type

--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -41,5 +41,66 @@ if exists('g:loaded_ctrlp')
   hi! link CtrlPBufferHid Normal
 endif
 " }}}
+" Tree-sitter: {{{
+if exists('g:loaded_nvim_treesitter')
+  " # Misc
+  hi! link TSError DraculaRed
+  hi! link TSPunctDelimiter Normal
+  hi! link TSPunctBracket Normal
+  hi! link TSPunctSpecial Normal
+  " # Constants
+  hi! link TSConstant DraculaPurple
+  hi! link TSConstBuiltin DraculaPurple
+  hi! link TSConstMacro DraculaCyan
+  hi! link TSStringRegex DraculaYellow
+  hi! link TSString DraculaYellow
+  hi! link TSStringEscape DraculaCyan
+  hi! link TSSymbol DraculaPurple
+  hi! link TSCharacter DraculaGreen
+  hi! link TSNumber DraculaPurple
+  hi! link TSBoolean DraculaPurple
+  hi! link TSFloat DraculaPurple
+  hi! link TSAnnotation DraculaYellow
+  hi! link TSAttribute DraculaCyan
+  hi! link TSNamespace DraculaPink
+  " # Functions
+  hi! link TSFuncBuiltin DraculaCyan
+  hi! link TSFunction DraculaGreen
+  hi! link TSFuncMacro DraculaGreen
+  hi! link TSParameter DraculaOrange
+  hi! link TSParameterReference DraculaOrange
+  hi! link TSMethod DraculaGreen
+  hi! link TSField DraculaOrange
+  hi! link TSProperty Normal
+  hi! link TSConstructor DraculaCyan
+  " # Keywords
+  hi! link TSConditional DraculaPink
+  hi! link TSRepeat DraculaPink
+  hi! link TSLabel DraculaPurpleItalic
+  hi! link TSKeyword DraculaPink
+  hi! link TSKeywordFunction DraculaCyan
+  hi! link TSKeywordOperator DraculaPink
+  hi! link TSOperator DraculaPink
+  hi! link TSException DraculaPurple
+  hi! link TSType DraculaCyanItalic
+  hi! link TSTypeBuiltin DraculaCyanItalic
+  hi! link TSStructure DraculaPurple
+  hi! link TSInclude DraculaPink
+  " # Variable
+  hi! link TSVariable Normal
+  hi! link TSVariableBuiltin DraculaPurple
+  " # Text
+  hi! link TSText DraculaYellow
+  hi! link TSStrong DraculaYellowBold
+  hi! link TSEmphasis DraculaYellowItalic
+  hi! link TSUnderline DraculaYellowUnderline
+  hi! link TSTitle DraculaYellow
+  hi! link TSLiteral DraculaYellow
+  hi! link TSURI DraculaYellow
+  " # Tags
+  hi! link TSTag DraculaCyan
+  hi! link TSTagDelimiter Normal
+endif
+" }}}
 
 " vim: fdm=marker ts=2 sts=2 sw=2 fdl=0:

--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -44,56 +44,56 @@ endif
 " Tree-sitter: {{{
 if exists('g:loaded_nvim_treesitter')
   " # Misc
-  hi! link TSError DraculaRed
-  hi! link TSPunctDelimiter Normal
+  hi! link TSError ErrorMsg
+  hi! link TSPunctDelimiter Delimiter
   hi! link TSPunctBracket Normal
-  hi! link TSPunctSpecial Normal
+  hi! link TSPunctSpecial Special
   " # Constants
-  hi! link TSConstant DraculaPurple
-  hi! link TSConstBuiltin DraculaPurple
-  hi! link TSConstMacro DraculaCyan
-  hi! link TSStringRegex DraculaYellow
-  hi! link TSString DraculaYellow
-  hi! link TSStringEscape DraculaPink
+  hi! link TSConstant Constant
+  hi! link TSConstBuiltin Constant
+  hi! link TSConstMacro Macro
+  hi! link TSStringRegex String
+  hi! link TSString String
+  hi! link TSStringEscape Character
   hi! link TSSymbol DraculaPurple
-  hi! link TSCharacter DraculaGreen
-  hi! link TSNumber DraculaPurple
-  hi! link TSBoolean DraculaPurple
-  hi! link TSFloat DraculaPurple
+  hi! link TSCharacter Character
+  hi! link TSNumber Number
+  hi! link TSBoolean Boolean
+  hi! link TSFloat Float
   hi! link TSAnnotation DraculaYellow
   hi! link TSAttribute DraculaGreenItalic
-  hi! link TSNamespace DraculaPink
+  hi! link TSNamespace Structure
   " # Functions
   hi! link TSFuncBuiltin DraculaCyan
-  hi! link TSFunction DraculaGreen
-  hi! link TSFuncMacro DraculaGreen
+  hi! link TSFunction Function
+  hi! link TSFuncMacro Function
   hi! link TSParameter DraculaOrangeItalic
   hi! link TSParameterReference DraculaOrange
-  hi! link TSMethod DraculaGreen
+  hi! link TSMethod Function
   hi! link TSField DraculaOrange
   hi! link TSProperty Normal
   hi! link TSConstructor DraculaCyan
   " # Keywords
-  hi! link TSConditional DraculaPink
+  hi! link TSConditional Conditional
   hi! link TSRepeat DraculaPink
   hi! link TSLabel DraculaPurpleItalic
-  hi! link TSKeyword DraculaPink
+  hi! link TSKeyword Keyword
   hi! link TSKeywordFunction DraculaCyan
   hi! link TSKeywordOperator DraculaPink
-  hi! link TSOperator DraculaPink
+  hi! link TSOperator Operator
   hi! link TSException DraculaPurple
-  hi! link TSType DraculaCyanItalic
-  hi! link TSTypeBuiltin DraculaCyanItalic
-  hi! link TSStructure DraculaPurple
-  hi! link TSInclude DraculaPink
+  hi! link TSType Type
+  hi! link TSTypeBuiltin Type
+  hi! link TSStructure Structure
+  hi! link TSInclude Include
   " # Variable
   hi! link TSVariable Normal
   hi! link TSVariableBuiltin DraculaPurpleItalic
   " # Text
-  hi! link TSText DraculaFg
-  hi! link TSStrong DraculaFg
+  hi! link TSText Normal
+  hi! link TSStrong DraculaFgBold
   hi! link TSEmphasis DraculaFg
-  hi! link TSUnderline DraculaFg
+  hi! link TSUnderline Underlined
   hi! link TSTitle DraculaYellow
   hi! link TSLiteral DraculaYellow
   hi! link TSURI DraculaYellow

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -174,7 +174,9 @@ call s:h('DraculaRed', s:red)
 call s:h('DraculaRedInverse', s:fg, s:red)
 
 call s:h('DraculaYellow', s:yellow)
+call s:h('DraculaYellowBold', s:yellow, s:none, [s:attrs.bold])
 call s:h('DraculaYellowItalic', s:yellow, s:none, [s:attrs.italic])
+call s:h('DraculaYellowUnderline', s:yellow, s:none, [s:attrs.underline])
 
 call s:h('DraculaError', s:red, s:none, [], s:red)
 

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -174,9 +174,7 @@ call s:h('DraculaRed', s:red)
 call s:h('DraculaRedInverse', s:fg, s:red)
 
 call s:h('DraculaYellow', s:yellow)
-call s:h('DraculaYellowBold', s:yellow, s:none, [s:attrs.bold])
 call s:h('DraculaYellowItalic', s:yellow, s:none, [s:attrs.italic])
-call s:h('DraculaYellowUnderline', s:yellow, s:none, [s:attrs.underline])
 
 call s:h('DraculaError', s:red, s:none, [], s:red)
 


### PR DESCRIPTION
# What

The neovim project [nvim-treesitter/nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) ands some additional highlight groups for better syntax highlighting. I've adapted the work done by @nitishvelu in [ChristianChiarulli/nvcode-color-schemes.vim#14](https://github.com/ChristianChiarulli/nvcode-color-schemes.vim/pull/14) to support the treesitter hightlighting and would like to get it merged upstream in the main `dracula/vim` plugin.

## Rust

**Left**: Highlighting with nvim-treesitter

**Right**: Existing highlighting

<img width="1915" alt="Screen Shot 2021-03-04 at 13 03 32" src="https://user-images.githubusercontent.com/6456191/109998142-84141700-7ceb-11eb-95a8-e3805bd0b0ed.png">

## Ruby

**Left**: Highlighting with nvim-treesitter

**Right**: Existing highlighting

<img width="1919" alt="Screen Shot 2021-03-04 at 13 05 21" src="https://user-images.githubusercontent.com/6456191/109998115-7d859f80-7ceb-11eb-94b7-097c909bcdef.png">
