### PR TITLE
Update treesitter highlight groups + remove syntax error highlights

### DIFF
--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -45,61 +45,31 @@ endif
 if exists('g:loaded_nvim_treesitter')
   " # Misc
   hi! link TSError ErrorMsg
-  hi! link TSPunctDelimiter Delimiter
-  hi! link TSPunctBracket Normal
   hi! link TSPunctSpecial Special
   " # Constants
-  hi! link TSConstant Constant
-  hi! link TSConstBuiltin Constant
   hi! link TSConstMacro Macro
-  hi! link TSStringRegex String
-  hi! link TSString String
   hi! link TSStringEscape Character
   hi! link TSSymbol DraculaPurple
-  hi! link TSCharacter Character
-  hi! link TSNumber Number
-  hi! link TSBoolean Boolean
-  hi! link TSFloat Float
   hi! link TSAnnotation DraculaYellow
   hi! link TSAttribute DraculaGreenItalic
-  hi! link TSNamespace Structure
   " # Functions
   hi! link TSFuncBuiltin DraculaCyan
-  hi! link TSFunction Function
   hi! link TSFuncMacro Function
   hi! link TSParameter DraculaOrangeItalic
   hi! link TSParameterReference DraculaOrange
-  hi! link TSMethod Function
   hi! link TSField DraculaOrange
-  hi! link TSProperty Normal
   hi! link TSConstructor DraculaCyan
   " # Keywords
-  hi! link TSConditional Conditional
-  hi! link TSRepeat DraculaPink
   hi! link TSLabel DraculaPurpleItalic
-  hi! link TSKeyword Keyword
-  hi! link TSKeywordFunction DraculaCyan
-  hi! link TSKeywordOperator Operator
-  hi! link TSOperator Operator
-  hi! link TSException DraculaPurple
-  hi! link TSType Type
-  hi! link TSTypeBuiltin Type
-  hi! link TSStructure Structure
-  hi! link TSInclude Include
   " # Variable
-  hi! link TSVariable Normal
   hi! link TSVariableBuiltin DraculaPurpleItalic
   " # Text
-  hi! link TSText Normal
   hi! link TSStrong DraculaFgBold
   hi! link TSEmphasis DraculaFg
   hi! link TSUnderline Underlined
   hi! link TSTitle DraculaYellow
   hi! link TSLiteral DraculaYellow
   hi! link TSURI DraculaYellow
-  " # Tags
-  hi! link TSTag DraculaCyan
-  hi! link TSTagDelimiter Normal
 endif
 " }}}
 

--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -44,7 +44,6 @@ endif
 " Tree-sitter: {{{
 if exists('g:loaded_nvim_treesitter')
   " # Misc
-  hi! link TSError ErrorMsg
   hi! link TSPunctSpecial Special
   " # Constants
   hi! link TSConstMacro Macro


### PR DESCRIPTION
 # What

I have 2 fixes for #230:

1) I removed duplicates when comparing with the treesitter defaults https://github.com/nvim-treesitter/nvim-treesitter/blob/master/plugin/nvim-treesitter.vim
2) I removed the highlight for `TSError`

I discovered that `TSError` is used for syntax errors from treesitter. These errors are very common, since treesitter is an incremental parser, it parses changes to the file regularly, and often in the middle of typing new code. This causes the invalid syntax to get highlighted with `TSError` as described in https://github.com/nvim-treesitter/nvim-treesitter/issues/78#issuecomment-647140700. More often than not we want to ignore invalid syntax while typing, so I've removed the highlight for `TSError`.

I don't think this will fix the root cause of https://github.com/dracula/vim/issues/231, however, I discovered this issue will attempting to debug it and this should provide a bandaid to the bad experience.
