### PR TITLE
Add GitGutter/GitSigns highlighting

### DIFF
--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -41,6 +41,26 @@ if exists('g:loaded_ctrlp')
   hi! link CtrlPBufferHid Normal
 endif
 " }}}
+" GitGutter / gitsigns: {{{
+if exists('g:loaded_gitgutter')
+  hi! link GitGutterAdd    DiffAdd
+  hi! link GitGutterChange DiffChange
+  hi! link GitGutterDelete DiffDelete
+endif
+if has('nvim-0.5') && luaeval("pcall(require, 'gitsigns')")
+  " https://github.com/lewis6991/gitsigns.nvim requires nvim > 0.5
+  " has('nvim-0.5') checks >= 0.5, so this should be future-proof.
+  hi! link GitSignsAdd      DiffAdd
+  hi! link GitSignsAddLn    DiffAdd
+  hi! link GitSignsAddNr    DiffAdd
+  hi! link GitSignsChange   DiffChange
+  hi! link GitSignsChangeLn DiffChange
+  hi! link GitSignsChangeNr DiffChange
+  hi! link GitSignsDelete   DiffDelete
+  hi! link GitSignsDeleteLn DiffDelete
+  hi! link GitSignsDeleteNr DiffDelete
+endif
+" }}}
 " Tree-sitter: {{{
 if exists('g:loaded_nvim_treesitter')
   " # Misc


### PR DESCRIPTION
This adds specific highlight groups for GitGutter-related things.
It piggybacks off of the `Diff*` highlight groups.

See these related links in from [gitsigns](https://github.com/lewis6991/gitsigns.nvim):
https://github.com/lewis6991/gitsigns.nvim/issues/54
https://github.com/lewis6991/gitsigns.nvim/commit/317750d66a572588eef9a23fefce4aff1cbcad94

The `gitsigns.nvim` maintainer [suggested](https://github.com/lewis6991/gitsigns.nvim/issues/94) that this be implemented by checking if neovim is >= version 0.5, and if the package is available (as opposed to a variable like `g:loaded_gitsigns`). This is because `gitsigns` is essentially lazy-loaded so checking the variable when Dracula loads might be too early.

Before:
![Before](https://user-images.githubusercontent.com/280972/111194058-06b49600-8578-11eb-9b52-4410043d9191.png)

After:
![After](https://user-images.githubusercontent.com/280972/111194071-0caa7700-8578-11eb-954c-5aa34d313a8c.png)