### PR TITLE
fix(nvim): Add LspReference* groups

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -250,6 +250,9 @@ call s:h('Conceal', s:cyan, s:none)
 " Neovim uses SpecialKey for escape characters only. Vim uses it for that, plus whitespace.
 if has('nvim')
   hi! link SpecialKey DraculaRed
+  hi! link LspReferenceText DraculaSelection
+  hi! link LspReferenceRead DraculaSelection
+  hi! link LspReferenceWrite DraculaSelection
   hi! link LspDiagnosticsDefaultInformation DraculaCyan
   hi! link LspDiagnosticsDefaultHint DraculaCyan
   hi! link LspDiagnosticsDefaultError DraculaError


### PR DESCRIPTION

Adds LspReference groups so that the reference highlighting feature
works for neovim built-in LSP.

Before:

![Screenshot 2021-04-07 at 19 29 44](https://user-images.githubusercontent.com/5530639/113916197-9ea04b00-97d7-11eb-8175-0f16ce34daa0.png)

After:

![Screenshot 2021-04-07 at 19 30 28](https://user-images.githubusercontent.com/5530639/113916299-b7a8fc00-97d7-11eb-8626-8a2541a47191.png)


