### PR TITLE
update highlights for pangloss/vim-javascript

### DIFF
--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -10,6 +10,8 @@ hi! link javaScriptFunction Keyword
 " pangloss/vim-javascript {{{
 
 hi! link jsArrowFunction           Operator
+hi! link jsBuiltins                DraculaCyan
+hi! link jsClassDefinition         DraculaCyan
 hi! link jsClassMethodType         Keyword
 hi! link jsDestructuringAssignment DraculaOrangeItalic
 hi! link jsDocParam                DraculaOrangeItalic
@@ -17,8 +19,14 @@ hi! link jsDocTags                 Keyword
 hi! link jsDocType                 Type
 hi! link jsDocTypeBrackets         DraculaCyan
 hi! link jsFuncArgOperator         Operator
+hi! link jsFuncArgs                DraculaOrangeItalic
 hi! link jsFunction                Keyword
+hi! link jsNull                    Constant
+hi! link jsObjectColon             DraculaPink
+hi! link jsSuper                   DraculaPurpleItalic
 hi! link jsTemplateBraces          Special
+hi! link jsThis                    DraculaPurpleItalic
+hi! link jsUndefined               Constant
 
 "}}}
 


### PR DESCRIPTION
Hello again!

I took some time to try and improve the highlight groups for [pangloss/vim-javascript](https://github.com/pangloss/vim-javascript/)

I tried to follow the spec as closely as possible

- `jsBuiltins` -> `BuiltInFunctions (DraculaCyan)`
- `jsClassDefinition` -> `ClassName (DraculaCyan)`
- `jsFuncArgs` -> `FunctionParameters (DraculaOrangeItalic)`
- `jsNull` -> `Constant (Constant)`
- `jsObjectColon` -> `SeparatorsReferencesOrAccessors (DraculaPink)`
- `jsSuper` -> `InstanceReservedWords (DraculaPupleItalic)`
- `jsThis` -> `InstanceReservedWords (DraculaPupleItalic)`
- `jsUndefined` -> `Constant (Constant)`

Here's the result next to the VSCode implementation as a reference:

![dracula-js-comparison](https://user-images.githubusercontent.com/56110730/114748503-4a0a4c00-9d52-11eb-9a5e-8e75a78b9f37.png)
