### PR TITLE
change SpecialKey to DraculaPink (vim only)

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -262,7 +262,7 @@ if has('nvim')
   hi! link LspDiagnosticsUnderlineInformation DraculaInfoLine
   hi! link LspDiagnosticsUnderlineWarning DraculaWarnLine
 else
-  hi! link SpecialKey DraculaSubtle
+  hi! link SpecialKey DraculaPink
 endif
 
 hi! link Comment DraculaComment


### PR DESCRIPTION
@dsifford this is my attempt to fix some of the listchars issues for vim. It does make some parts of `'listchars'` pink:

```
"SpecialKey" for "nbsp", "space", "tab" and "trail".
```

---

Related: #210, #248

Also #192 is about listchars + cursorline in NeoVim, which this doesn't target
Also #247 is about `NonText`, which needs investigating.

Issues: `:digraphs`, special keys in `:map` output, and certain parts of
`'listchars'` are "subtle" and hard to read (esp. w/ `cursorline` over
them). Also, vim uses `SpecialKey` for them (instead of `Whitespace` for
`'listchars'` and `SpecialKey` elsewhere, like NeoVim).

Fix: make `SpecialKey` more like special keys (the highlight in vimscript
for, e.g., `map <Space> :echo "hello"<CR>`). This has the side effect of
making digraphs more visible. It also makes certain `'listchars'` pink,
which may be annoying. But there is no way currently to separate the two
in vim.

Rationale: It matches with the special keys in maps. The fact that vim
uses it elsewhere may simply be "wrong" and need changed.

If you don't like it: well, as usual, you can use an autocommand to use
whatever colors you want (`:help dracula-customization`).

<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->
