### PR TITLE
Highlight tag attributes via tree-sitter.

### DIFF
--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -89,6 +89,8 @@ if exists('g:loaded_nvim_treesitter')
   hi! link TSTitle DraculaYellow
   hi! link TSLiteral DraculaYellow
   hi! link TSURI DraculaYellow
+  " # Tags
+  hi! link TSTagAttribute DraculaGreenItalic
 endif
 " }}}
 

--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -62,6 +62,11 @@ if has('nvim-0.5') && luaeval("pcall(require, 'gitsigns')")
 endif
 " }}}
 " Tree-sitter: {{{
+" The nvim-treesitter library defines many global highlight groups that are
+" linked to the regular vim syntax highlight groups. We only need to redefine
+" those highlight groups when the defaults do not match the dracula
+" specification.
+" https://github.com/nvim-treesitter/nvim-treesitter/blob/master/plugin/nvim-treesitter.vim
 if exists('g:loaded_nvim_treesitter')
   " # Misc
   hi! link TSPunctSpecial Special
@@ -89,7 +94,8 @@ if exists('g:loaded_nvim_treesitter')
   hi! link TSTitle DraculaYellow
   hi! link TSLiteral DraculaYellow
   hi! link TSURI DraculaYellow
-  " # Tags
+  " HTML and JSX tag attributes. By default, this group is linked to TSProperty,
+  " which in turn links to Identifer (white).
   hi! link TSTagAttribute DraculaGreenItalic
 endif
 " }}}


### PR DESCRIPTION
This pull request sets the [correct color](https://spec.draculatheme.com/#HtmlCssAttributeNames) (italic green) for the  `TSTagAttribute` highlight group used by treesitter for tag attributes in JSX. By default, the nvim-treesitter package links `TSTagAttribute` to `TSProperty`, which in turns links to `Identifier`, which makes the attributes appear as white text.

Before:
![Screen Shot 2021-07-17 at 7 35 46 PM](https://user-images.githubusercontent.com/1218900/126053664-a6068408-0552-4999-b813-a11924554e31.png)

After:
![Screen Shot 2021-07-17 at 7 24 24 PM](https://user-images.githubusercontent.com/1218900/126053673-3f743b2c-1798-427d-9e47-13accfac06a2.png)



