### PR TITLE
Use termguicolors

### DIFF
--- a/autoload/dracula.vim
+++ b/autoload/dracula.vim
@@ -54,4 +54,13 @@ func! dracula#should_abort(...)
     return 0
 endfunction
 
+" Use termguicolors instead of 256
+if (has('nvim'))
+  let $NVIM_TUI_ENABLE_TRUE_COLOR = 1
+endif
+
+if (has('termguicolors'))
+  set termguicolors
+endif
+
 " vim: fdm=marker ts=2 sts=2 sw=2 fdl=0:


### PR DESCRIPTION
Fixes neovim displaying cterm 256 colors, it should always use gui hexadecimal colors instead. this only applies if termguicolors is available for the terminal. this can save a lot of "colors not displaying correctly" issues.

Before:
![2021-07-21_22-30_1](https://user-images.githubusercontent.com/56526315/126586898-3267b125-6e0d-483c-9a43-de6d5b6956b1.png)

After:
![2021-07-21_22-30](https://user-images.githubusercontent.com/56526315/126586933-42aece4e-4674-474f-ac7d-55ccd0b85176.png)

(difference in the background and status line)