### PR TITLE
Add nvim-cmp kind highlights

### DIFF
--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -99,5 +99,41 @@ if exists('g:loaded_nvim_treesitter')
   hi! link TSTagAttribute DraculaGreenItalic
 endif
 " }}}
+" nvim-cmp: {{{
+" A completion engine plugin for neovim written in Lua.
+" https://github.com/hrsh7th/nvim-cmp
+if exists('g:loaded_cmp')
+  hi! link CmpItemAbbrDeprecated DraculaError
+
+  hi! link CmpItemAbbrMatch DraculaFg
+  hi! link CmpItemAbbrMatchFuzzy DraculaFg
+
+  hi! link CmpItemKindText DraculaFg
+  hi! link CmpItemKindMethod Function
+  hi! link CmpItemKindFunction Function
+  hi! link CmpItemKindConstructor DraculaCyan
+  hi! link CmpItemKindField DraculaOrange
+  hi! link CmpItemKindVariable DraculaPurpleItalic
+  hi! link CmpItemKindClass DraculaCyan
+  hi! link CmpItemKindInterface DraculaCyan
+  hi! link CmpItemKindModule DraculaYellow
+  hi! link CmpItemKindProperty DraculaPink
+  hi! link CmpItemKindUnit DraculaFg
+  hi! link CmpItemKindValue DraculaYellow
+  hi! link CmpItemKindEnum DraculaPink
+  hi! link CmpItemKindKeyword DraculaPink
+  hi! link CmpItemKindSnippet DraculaFg
+  hi! link CmpItemKindColor DraculaYellow
+  hi! link CmpItemKindFile DraculaYellow
+  hi! link CmpItemKindReference DraculaOrange
+  hi! link CmpItemKindFolder DraculaYellow
+  hi! link CmpItemKindEnumMember DraculaPurple
+  hi! link CmpItemKindConstant DraculaPurple
+  hi! link CmpItemKindStruct DraculaPink
+  hi! link CmpItemKindEvent DraculaFg
+  hi! link CmpItemKindOperator DraculaPink
+  hi! link CmpItemKindTypeParameter DraculaCyan
+endif
+" }}}
 
 " vim: fdm=marker ts=2 sts=2 sw=2 fdl=0:


### PR DESCRIPTION
This adds new highlights for [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) kinds. I tried to follow treesitter's lead as far as sticking to the spec.

Related PR where kind highlights were implemented:
https://github.com/hrsh7th/nvim-cmp/pull/584

Example in Python:
![2021-12-09-225657_709x827_scrot](https://user-images.githubusercontent.com/64174376/145516008-52d613c1-3546-440a-bd4b-d2cfb7d1829e.png)

