### PR TITLE
Update highlights for nvim-cmp

### DIFF
--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -105,8 +105,8 @@ endif
 if exists('g:loaded_cmp')
   hi! link CmpItemAbbrDeprecated DraculaError
 
-  hi! link CmpItemAbbrMatch DraculaFg
-  hi! link CmpItemAbbrMatchFuzzy DraculaFg
+  hi! link CmpItemAbbrMatch DraculaCyan
+  hi! link CmpItemAbbrMatchFuzzy DraculaCyan
 
   hi! link CmpItemKindText DraculaFg
   hi! link CmpItemKindMethod Function


### PR DESCRIPTION
<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->
`CmpItemAbbrMatch` and `CmpItemAbbrMatchFuzzy` were not highlighted.
I tried updating the highlighting with the same colors as dracula/visual-studio-code.
before:
![before](https://user-images.githubusercontent.com/29335192/149654333-d23f083a-1f28-43b3-86ee-7ccaa327f1fd.png)

after:
![after](https://user-images.githubusercontent.com/29335192/149654337-2b81bec9-e8c7-4d2b-a872-e46df4c3e228.png)

vscode:
![vscode](https://user-images.githubusercontent.com/29335192/149654361-1ac9282e-f0f7-497a-87ff-1371d59ff15b.png)


