### PR TITLE
Add nvim-cmp menu highlight

### DIFF
--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -133,6 +133,8 @@ if exists('g:loaded_cmp')
   hi! link CmpItemKindEvent DraculaFg
   hi! link CmpItemKindOperator DraculaPink
   hi! link CmpItemKindTypeParameter DraculaCyan
+
+  hi! link CmpItemMenu Comment
 endif
 " }}}
 


### PR DESCRIPTION
<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->
Hi, thanks for maintaining a great color scheme!

When I was updating `CmpItemAbbrMatch`, I took a look at the other color schemes as well.
I noticed then that in tokyonight and kanagawa, `CmpItemMenu` is an inconspicuous color.
`CmpItemMenu` is `[LSP]` in the following image.
![menu_before](https://user-images.githubusercontent.com/29335192/149803277-28081133-5070-48c1-82b1-be7c15435750.png)

CmpItemMenu is a completion source, and I consider it better to have an inconspicuous color, as shown in comments.
The image with this modification is shown below.
![menu_after](https://user-images.githubusercontent.com/29335192/149803701-4cc06d85-23c2-4f55-97cf-be4bb8b4acb1.png)

What do you think about this modification?
Does it keep the Doracula feel?
