### PR TITLE
feat(nvim): Add support for WinSeparator

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -194,7 +194,7 @@ call s:h('DraculaInfoLine', s:none, s:none, [s:attrs.undercurl], s:cyan)
 call s:h('DraculaTodo', s:cyan, s:none, [s:attrs.bold, s:attrs.inverse])
 call s:h('DraculaSearch', s:green, s:none, [s:attrs.inverse])
 call s:h('DraculaBoundary', s:comment, s:bgdark)
-call s:h('DraculaSeparator', s:comment, s:none)
+call s:h('DraculaWinSeparator', s:comment, s:bgdark)
 call s:h('DraculaLink', s:cyan, s:none, [s:attrs.underline])
 
 call s:h('DraculaDiffChange', s:orange, s:none)
@@ -245,13 +245,13 @@ hi! link TabLine      DraculaBoundary
 hi! link TabLineFill  DraculaBgDark
 hi! link TabLineSel   Normal
 hi! link Title        DraculaGreenBold
-hi! link VertSplit    DraculaBoundary
+hi! link VertSplit    DraculaWinSeparator
 hi! link Visual       DraculaSelection
 hi! link VisualNOS    Visual
 hi! link WarningMsg   DraculaOrangeInverse
 
 if has('nvim')
-  hi! link WinSeparator DraculaSeparator
+  hi! link WinSeparator DraculaWinSeparator
 endif
 " }}}
 " Syntax: {{{

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -194,6 +194,7 @@ call s:h('DraculaInfoLine', s:none, s:none, [s:attrs.undercurl], s:cyan)
 call s:h('DraculaTodo', s:cyan, s:none, [s:attrs.bold, s:attrs.inverse])
 call s:h('DraculaSearch', s:green, s:none, [s:attrs.inverse])
 call s:h('DraculaBoundary', s:comment, s:bgdark)
+call s:h('DraculaSeparator', s:comment, s:none)
 call s:h('DraculaLink', s:cyan, s:none, [s:attrs.underline])
 
 call s:h('DraculaDiffChange', s:orange, s:none)
@@ -249,6 +250,9 @@ hi! link Visual       DraculaSelection
 hi! link VisualNOS    Visual
 hi! link WarningMsg   DraculaOrangeInverse
 
+if has('nvim')
+  hi! link WinSeparator DraculaSeparator
+endif
 " }}}
 " Syntax: {{{
 
@@ -272,7 +276,7 @@ if has('nvim')
   hi! link LspDiagnosticsUnderlineHint DiagnosticUnderlineHint
   hi! link LspDiagnosticsUnderlineInformation DiagnosticUnderlineInfo
   hi! link LspDiagnosticsUnderlineWarning DiagnosticUnderlineWarn
-  
+
   hi! link DiagnosticInfo DraculaCyan
   hi! link DiagnosticHint DraculaCyan
   hi! link DiagnosticError DraculaError

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -250,9 +250,6 @@ hi! link Visual       DraculaSelection
 hi! link VisualNOS    Visual
 hi! link WarningMsg   DraculaOrangeInverse
 
-if has('nvim')
-  hi! link WinSeparator DraculaWinSeparator
-endif
 " }}}
 " Syntax: {{{
 
@@ -285,6 +282,8 @@ if has('nvim')
   hi! link DiagnosticUnderlineHint DraculaInfoLine
   hi! link DiagnosticUnderlineInfo DraculaInfoLine
   hi! link DiagnosticUnderlineWarn DraculaWarnLine
+
+  hi! link WinSeparator DraculaWinSeparator
 else
   hi! link SpecialKey DraculaPink
 endif


### PR DESCRIPTION
<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->
Neovim [recently added](https://github.com/neovim/neovim/pull/17266) a feature for a global statusline. A new highlight group `WinSeparator` was created linking to `VertSplit` for compatibility. 

This colorscheme links `VertSplit` to `DraculaBoundary`. Because the statusline is no longer present on horizontal splits with this feature enabled, the `DraculaBoundary` group is used in between them. 

This PR changes the look of the separator for both vertical and horizontal splits using the new upstream group. A new group `DraculaSeparator` is introduced for this purpose.

For comparison. The default behavior would use the `DraculaBoundary` group. With the statusline removed, the border is uneven.
![old-winseparator](https://user-images.githubusercontent.com/64174376/159141087-b5815c78-3b2f-43f5-91f1-53d027123b05.png)

Neovim master with the new `DraculaSeparator` group.
![new-winseparator](https://user-images.githubusercontent.com/64174376/159141086-9be2bdc5-2053-435f-abe7-0963bd7a3cb7.png)

This does change the existing look of vertical splits for Neovim users (> v0.7.0). Because of that I understand this may not be desired, or we would want to change `VertSplit` to use the `DraculaSeparator` group for consistency.