### PR TITLE
fix: support lazy-loading nvim-cmp

### DIFF
--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -102,7 +102,7 @@ endif
 " nvim-cmp: {{{
 " A completion engine plugin for neovim written in Lua.
 " https://github.com/hrsh7th/nvim-cmp
-if exists('g:loaded_cmp')
+function! s:set_cmp()
   hi! link CmpItemAbbrDeprecated DraculaError
 
   hi! link CmpItemAbbrMatch DraculaCyan
@@ -135,7 +135,12 @@ if exists('g:loaded_cmp')
   hi! link CmpItemKindTypeParameter DraculaCyan
 
   hi! link CmpItemMenu Comment
-endif
+endfunction
+
+augroup ___dracula_cmp___
+  au!
+  au User CmpReady call s:set_cmp()
+augroup END
 " }}}
 
 " vim: fdm=marker ts=2 sts=2 sw=2 fdl=0:


### PR DESCRIPTION
<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->
Often users of [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) lazy-load this plugin. If users do that, then the highlight groups defined by this scheme don't get loaded with the current guard setup. 

This proposes an autocmd which hooks into the [documented](https://github.com/hrsh7th/nvim-cmp/blob/main/doc/cmp.txt#L355)  `CmpReady` event, adding the highlights at that point.

Not sure how you feel about adding autocmds to the theme. I opted for a singular group `___dracula_cmp___` instead of a plugin-wide group (for example `___dracula___`).