### PR TITLE
Neovim: Update tree-sitter support for CSS

### DIFF
--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -101,7 +101,6 @@ if exists('g:loaded_nvim_treesitter')
 	hi! link TSPunctDelimiter DraculaPink
 	hi! link TSType DraculaPink
 	hi! link TSProperty DraculaCyan
-	hi! link TSFunction DraculaGreenItalic
 	hi! link TSError DraculaOrange
 endif
 " }}}

--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -97,6 +97,12 @@ if exists('g:loaded_nvim_treesitter')
   " HTML and JSX tag attributes. By default, this group is linked to TSProperty,
   " which in turn links to Identifer (white).
   hi! link TSTagAttribute DraculaGreenItalic
+	" CSS
+	hi! link TSPunctDelimiter DraculaPink
+	hi! link TSType DraculaPink
+	hi! link TSProperty DraculaCyan
+	hi! link TSFunction DraculaGreenItalic
+	hi! link TSError DraculaOrange
 endif
 " }}}
 " nvim-cmp: {{{


### PR DESCRIPTION
Hello!
I found that [dracula/vim](https://github.com/dracula/vim) worked well with HTML & JS via tree-sitter but not CSS. So I took some time to add some highlights for it; I tried to make it look like Vscode as much as possible.

### What I linked:
*  Make `,`, `.`, `;`, etc. become pink: `TSPunctDelimiter` -> `DraculaPink` 
*  Make selectors become pink:  `TSType` -> `DraculaPink`
*  Make classes, properties become cyan: `TSProperty` -> `DraculaCyan`
*  Make URLs become orange: `TSError` -> `DraculaOrange` (I was inspired by how [shaunsingh/nord.nvim](https://github.com/shaunsingh/nord.nvim) did it)

### Before:
![image](https://user-images.githubusercontent.com/57804513/184196891-470202ea-fadd-41fd-acd5-757b221d97ab.png)

### After:
![image](https://user-images.githubusercontent.com/57804513/184196713-54670b8b-0670-4f73-8a55-5366b749880d.png)


