### PR TITLE
Update treesitter highlight groups

### DIFF
--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -68,7 +68,7 @@ endif
 " specification.
 " https://github.com/nvim-treesitter/nvim-treesitter/blob/master/plugin/nvim-treesitter.vim
 if exists('g:loaded_nvim_treesitter')
-  " deplicated TS* highlight groups
+  " deprecated TS* highlight groups
   " see https://github.com/nvim-treesitter/nvim-treesitter/pull/3656
   " # Misc
   hi! link TSPunctSpecial Special

--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -100,50 +100,52 @@ if exists('g:loaded_nvim_treesitter')
   " which in turn links to Identifer (white).
   hi! link TSTagAttribute DraculaGreenItalic
 
-  " # Misc
-  hi! link @punctuation.delimiter Delimiter
-  hi! link @punctuation.bracket Normal
-  hi! link @punctuation.special Special
-  " # Constants
-  hi! link @constant Constant
-  hi! link @constant.builtin Constant
-  hi! link @constant.macro Macro
-  hi! link @string.regex String
-  hi! link @string.escape Character
-  hi! link @symbol DraculaPurple
-  hi! link @annotation DraculaYellow
-  hi! link @attribute DraculaGreenItalic
-  hi! link @namespace Structure
-  " # Functions
-  hi! link @function.builtin DraculaCyan
-  hi! link @funcion.macro Function
-  hi! link @parameter DraculaOrangeItalic
-  hi! link @parameter.reference DraculaOrange
-  hi! link @field DraculaOrange
-  hi! link @property Normal
-  hi! link @constructor DraculaCyan
-  " # Keywords
-  hi! link @label DraculaPurpleItalic
-  hi! link @keyword.function DraculaCyan
-  hi! link @keyword.operator Operator
-  hi! link @exception DraculaPurple
-  " # Variable
-  hi! link @variable Normal
-  hi! link @variable.builtin DraculaPurpleItalic
-  " # Text
-  hi! link @text Normal
-  hi! link @text.strong DraculaFgBold
-  hi! link @text.emphasis DraculaFg
-  hi! link @text.underline Underlined
-  hi! link @text.title DraculaYellow
-  hi! link @text.literal DraculaYellow
-  hi! link @text.uri DraculaYellow
-  " # Tags
-  hi! link @tag DraculaCyan
-  hi! link @tag.delimiter Normal
-  " HTML and JSX tag attributes. By default, this group is linked to TSProperty,
-  " which in turn links to Identifer (white).
-  hi! link @tag.attribute DraculaGreenItalic
+  if has('nvim-0.8')
+    " # Misc
+    hi! link @punctuation.delimiter Delimiter
+    hi! link @punctuation.bracket Normal
+    hi! link @punctuation.special Special
+    " # Constants
+    hi! link @constant Constant
+    hi! link @constant.builtin Constant
+    hi! link @constant.macro Macro
+    hi! link @string.regex String
+    hi! link @string.escape Character
+    hi! link @symbol DraculaPurple
+    hi! link @annotation DraculaYellow
+    hi! link @attribute DraculaGreenItalic
+    hi! link @namespace Structure
+    " # Functions
+    hi! link @function.builtin DraculaCyan
+    hi! link @funcion.macro Function
+    hi! link @parameter DraculaOrangeItalic
+    hi! link @parameter.reference DraculaOrange
+    hi! link @field DraculaOrange
+    hi! link @property Normal
+    hi! link @constructor DraculaCyan
+    " # Keywords
+    hi! link @label DraculaPurpleItalic
+    hi! link @keyword.function DraculaCyan
+    hi! link @keyword.operator Operator
+    hi! link @exception DraculaPurple
+    " # Variable
+    hi! link @variable Normal
+    hi! link @variable.builtin DraculaPurpleItalic
+    " # Text
+    hi! link @text Normal
+    hi! link @text.strong DraculaFgBold
+    hi! link @text.emphasis DraculaFg
+    hi! link @text.underline Underlined
+    hi! link @text.title DraculaYellow
+    hi! link @text.literal DraculaYellow
+    hi! link @text.uri DraculaYellow
+    " # Tags
+    hi! link @tag DraculaCyan
+    hi! link @tag.delimiter Normal
+    " HTML and JSX tag attributes. By default, this group is linked to TSProperty,
+    " which in turn links to Identifer (white).
+    hi! link @tag.attribute DraculaGreenItalic
+  endif
 endif
 " }}}
 " nvim-cmp: {{{

--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -68,6 +68,38 @@ endif
 " specification.
 " https://github.com/nvim-treesitter/nvim-treesitter/blob/master/plugin/nvim-treesitter.vim
 if exists('g:loaded_nvim_treesitter')
+  " deplicated TS* highlight groups
+  " see https://github.com/nvim-treesitter/nvim-treesitter/pull/3656
+  " # Misc
+  hi! link TSPunctSpecial Special
+  " # Constants
+  hi! link TSConstMacro Macro
+  hi! link TSStringEscape Character
+  hi! link TSSymbol DraculaPurple
+  hi! link TSAnnotation DraculaYellow
+  hi! link TSAttribute DraculaGreenItalic
+  " # Functions
+  hi! link TSFuncBuiltin DraculaCyan
+  hi! link TSFuncMacro Function
+  hi! link TSParameter DraculaOrangeItalic
+  hi! link TSParameterReference DraculaOrange
+  hi! link TSField DraculaOrange
+  hi! link TSConstructor DraculaCyan
+  " # Keywords
+  hi! link TSLabel DraculaPurpleItalic
+  " # Variable
+  hi! link TSVariableBuiltin DraculaPurpleItalic
+  " # Text
+  hi! link TSStrong DraculaFgBold
+  hi! link TSEmphasis DraculaFg
+  hi! link TSUnderline Underlined
+  hi! link TSTitle DraculaYellow
+  hi! link TSLiteral DraculaYellow
+  hi! link TSURI DraculaYellow
+  " HTML and JSX tag attributes. By default, this group is linked to TSProperty,
+  " which in turn links to Identifer (white).
+  hi! link TSTagAttribute DraculaGreenItalic
+
   " # Misc
   hi! link @punctuation.delimiter Delimiter
   hi! link @punctuation.bracket Normal

--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -69,31 +69,46 @@ endif
 " https://github.com/nvim-treesitter/nvim-treesitter/blob/master/plugin/nvim-treesitter.vim
 if exists('g:loaded_nvim_treesitter')
   " # Misc
+  hi! link @punctuation.delimiter Delimiter
+  hi! link @punctuation.bracket Normal
   hi! link @punctuation.special Special
   " # Constants
+  hi! link @constant Constant
+  hi! link @constant.builtin Constant
   hi! link @constant.macro Macro
+  hi! link @string.regex String
   hi! link @string.escape Character
   hi! link @symbol DraculaPurple
   hi! link @annotation DraculaYellow
   hi! link @attribute DraculaGreenItalic
+  hi! link @namespace Structure
   " # Functions
   hi! link @function.builtin DraculaCyan
   hi! link @funcion.macro Function
   hi! link @parameter DraculaOrangeItalic
   hi! link @parameter.reference DraculaOrange
   hi! link @field DraculaOrange
+  hi! link @property Normal
   hi! link @constructor DraculaCyan
   " # Keywords
   hi! link @label DraculaPurpleItalic
+  hi! link @keyword.function DraculaCyan
+  hi! link @keyword.operator Operator
+  hi! link @exception DraculaPurple
   " # Variable
+  hi! link @variable Normal
   hi! link @variable.builtin DraculaPurpleItalic
   " # Text
+  hi! link @text Normal
   hi! link @text.strong DraculaFgBold
   hi! link @text.emphasis DraculaFg
   hi! link @text.underline Underlined
   hi! link @text.title DraculaYellow
   hi! link @text.literal DraculaYellow
   hi! link @text.uri DraculaYellow
+  " # Tags
+  hi! link @tag DraculaCyan
+  hi! link @tag.delimiter Normal
   " HTML and JSX tag attributes. By default, this group is linked to TSProperty,
   " which in turn links to Identifer (white).
   hi! link @tag.attribute DraculaGreenItalic

--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -69,34 +69,34 @@ endif
 " https://github.com/nvim-treesitter/nvim-treesitter/blob/master/plugin/nvim-treesitter.vim
 if exists('g:loaded_nvim_treesitter')
   " # Misc
-  hi! link TSPunctSpecial Special
+  hi! link @punctuation.special Special
   " # Constants
-  hi! link TSConstMacro Macro
-  hi! link TSStringEscape Character
-  hi! link TSSymbol DraculaPurple
-  hi! link TSAnnotation DraculaYellow
-  hi! link TSAttribute DraculaGreenItalic
+  hi! link @constant.macro Macro
+  hi! link @string.escape Character
+  hi! link @symbol DraculaPurple
+  hi! link @annotation DraculaYellow
+  hi! link @attribute DraculaGreenItalic
   " # Functions
-  hi! link TSFuncBuiltin DraculaCyan
-  hi! link TSFuncMacro Function
-  hi! link TSParameter DraculaOrangeItalic
-  hi! link TSParameterReference DraculaOrange
-  hi! link TSField DraculaOrange
-  hi! link TSConstructor DraculaCyan
+  hi! link @function.builtin DraculaCyan
+  hi! link @funcion.macro Function
+  hi! link @parameter DraculaOrangeItalic
+  hi! link @parameter.reference DraculaOrange
+  hi! link @field DraculaOrange
+  hi! link @constructor DraculaCyan
   " # Keywords
-  hi! link TSLabel DraculaPurpleItalic
+  hi! link @label DraculaPurpleItalic
   " # Variable
-  hi! link TSVariableBuiltin DraculaPurpleItalic
+  hi! link @variable.builtin DraculaPurpleItalic
   " # Text
-  hi! link TSStrong DraculaFgBold
-  hi! link TSEmphasis DraculaFg
-  hi! link TSUnderline Underlined
-  hi! link TSTitle DraculaYellow
-  hi! link TSLiteral DraculaYellow
-  hi! link TSURI DraculaYellow
+  hi! link @text.strong DraculaFgBold
+  hi! link @text.emphasis DraculaFg
+  hi! link @text.underline Underlined
+  hi! link @text.title DraculaYellow
+  hi! link @text.literal DraculaYellow
+  hi! link @text.uri DraculaYellow
   " HTML and JSX tag attributes. By default, this group is linked to TSProperty,
   " which in turn links to Identifer (white).
-  hi! link TSTagAttribute DraculaGreenItalic
+  hi! link @tag.attribute DraculaGreenItalic
 endif
 " }}}
 " nvim-cmp: {{{


### PR DESCRIPTION
nvim-treesitter has removed `TS*` highlight groups.
Thus we need to use @foo.bar style highlight groups.

<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->
see https://github.com/nvim-treesitter/nvim-treesitter/pull/3656
