### PR TITLE
do not use green as high-contrast-diff bg color

### DIFF
--- a/autoload/dracula.vim
+++ b/autoload/dracula.vim
@@ -20,6 +20,7 @@ let g:dracula#palette.pink      = ['#FF79C6', 212]
 let g:dracula#palette.purple    = ['#BD93F9', 141]
 let g:dracula#palette.red       = ['#FF5555', 203]
 let g:dracula#palette.yellow    = ['#F1FA8C', 228]
+let g:dracula#palette.blue      = ['#003399',  18]
 
 "
 " ANSI

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -50,6 +50,7 @@ let s:pink      = g:dracula#palette.pink
 let s:purple    = g:dracula#palette.purple
 let s:red       = g:dracula#palette.red
 let s:yellow    = g:dracula#palette.yellow
+let s:blue      = g:dracula#palette.blue
 
 let s:none      = ['NONE', 'NONE']
 
@@ -202,7 +203,7 @@ call s:h('DraculaWinSeparator', s:comment, s:bgdark)
 call s:h('DraculaLink', s:cyan, s:none, [s:attrs.underline])
 
 if g:dracula_high_contrast_diff
-  call s:h('DraculaDiffChange', s:red, s:green)
+  call s:h('DraculaDiffChange', s:red, s:blue)
 else
   call s:h('DraculaDiffChange', s:orange, s:none)
 endif


### PR DESCRIPTION
...since it hides selected text in changed lines.


Sorry first issue comes quickly.
As following, the ```tracebitmap``` in line 950 get hidden because selected text also uses green bg-color.

I created the ```s:blue``` since it's not used for now.
It should avoid any potential conflict with current all used color-configs.


without fix:
![1](https://user-images.githubusercontent.com/1754214/198710120-c5193230-96fc-40d0-a32c-b0d42e8ba2ff.png)

with fix:
![2](https://user-images.githubusercontent.com/1754214/198710142-4ec0fdd4-042e-4ed7-95ac-69e5112b985f.png)


