### PR TITLE
use yellow/purple as high-contrast-diff color

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -202,7 +202,7 @@ call s:h('DraculaWinSeparator', s:comment, s:bgdark)
 call s:h('DraculaLink', s:cyan, s:none, [s:attrs.underline])
 
 if g:dracula_high_contrast_diff
-  call s:h('DraculaDiffChange', s:red, s:green)
+  call s:h('DraculaDiffChange', s:yellow, s:purple)
 else
   call s:h('DraculaDiffChange', s:orange, s:none)
 endif


### PR DESCRIPTION
continuation of #293 

use yellow/purple for high-contrast-diff color.
Looks purple/yellow is not used for text in buffer, should be safe now.

without fix:
![1](https://user-images.githubusercontent.com/1754214/198738867-23f2ae14-f77d-4d2f-9c84-6aed8bfeadba.png)

wtih fix
![2](https://user-images.githubusercontent.com/1754214/198738874-aa4af6e7-57ee-4e11-aceb-bcf3509b3e88.png)
