### PR TITLE
Add diff highlights for treesitter

### DIFF
--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -139,6 +139,8 @@ if exists('g:loaded_nvim_treesitter')
     hi! link @text.title DraculaYellow
     hi! link @text.literal DraculaYellow
     hi! link @text.uri DraculaYellow
+    hi! link @text.diff.add DiffAdd
+    hi! link @text.diff.delete DiffDelete
     " # Tags
     hi! link @tag DraculaCyan
     hi! link @tag.delimiter Normal


### PR DESCRIPTION
<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->
A diff parser has been added to treesitter and a new highlight group has been added.
https://github.com/nvim-treesitter/nvim-treesitter/pull/3684

Currently when using treesitter, the following display is shown.
<img width="727" alt="スクリーンショット 2022-11-30 13 00 08" src="https://user-images.githubusercontent.com/29335192/204760964-844a77f0-4cc6-4401-9d78-bab5c774c096.png">

If you apply this PR, you will see the following
<img width="727" alt="スクリーンショット 2022-11-30 13 01 44" src="https://user-images.githubusercontent.com/29335192/204760997-c347442e-3b56-445f-aee0-a4c3d72d0a64.png">
