### PR TITLE
give higher contrast to DraculaDiffDelete

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -203,12 +203,13 @@ call s:h('DraculaLink', s:cyan, s:none, [s:attrs.underline])
 
 if g:dracula_high_contrast_diff
   call s:h('DraculaDiffChange', s:yellow, s:purple)
+  call s:h('DraculaDiffDelete', s:bgdark, s:red)
 else
   call s:h('DraculaDiffChange', s:orange, s:none)
+  call s:h('DraculaDiffDelete', s:red, s:bgdark)
 endif
 
 call s:h('DraculaDiffText', s:bg, s:orange)
-call s:h('DraculaDiffDelete', s:red, s:bgdark)
 
 " }}}2
 


### PR DESCRIPTION
Please see if this makes sense to you as if to merge if you like.

For DraculaDiffDelete, the left side uses dark brackground, which is pretty close to normal background color.
My experience is it's misleading especially mixed with the code syntax color in massive diff.

It's under the option g:dracul_high_contrast_diff, so should be safe to keep old behavor for people don't like it.


before:
![before](https://user-images.githubusercontent.com/1754214/209228018-3e08d6da-bf2e-4d37-874a-d78161a21085.PNG)

after:
![after](https://user-images.githubusercontent.com/1754214/209228027-6c7c6b8b-904f-4077-8b70-ab13dd1830ab.PNG)

