### PR TITLE
Introduce gray color for SpecialKey

### DIFF
--- a/autoload/dracula.vim
+++ b/autoload/dracula.vim
@@ -14,6 +14,7 @@ let g:dracula#palette.selection = ['#44475A', 239]
 let g:dracula#palette.subtle    = ['#424450', 238]
 
 let g:dracula#palette.cyan      = ['#8BE9FD', 117]
+let g:dracula#palette.gray      = ['#616151', 128]
 let g:dracula#palette.green     = ['#50FA7B',  84]
 let g:dracula#palette.orange    = ['#FFB86C', 215]
 let g:dracula#palette.pink      = ['#FF79C6', 212]

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -44,6 +44,7 @@ let s:selection = g:dracula#palette.selection
 let s:subtle    = g:dracula#palette.subtle
 
 let s:cyan      = g:dracula#palette.cyan
+let s:gray      = g:dracula#palette.gray
 let s:green     = g:dracula#palette.green
 let s:orange    = g:dracula#palette.orange
 let s:pink      = g:dracula#palette.pink
@@ -165,6 +166,8 @@ call s:h('DraculaSubtle', s:subtle)
 call s:h('DraculaCyan', s:cyan)
 call s:h('DraculaCyanItalic', s:cyan, s:none, [s:attrs.italic])
 
+call s:h('DraculaGray', s:gray)
+
 call s:h('DraculaGreen', s:green)
 call s:h('DraculaGreenBold', s:green, s:none, [s:attrs.bold])
 call s:h('DraculaGreenItalic', s:green, s:none, [s:attrs.italic])
@@ -269,7 +272,7 @@ call s:h('Conceal', s:cyan, s:none)
 
 " Neovim uses SpecialKey for escape characters only. Vim uses it for that, plus whitespace.
 if has('nvim')
-  hi! link SpecialKey DraculaRed
+  hi! link SpecialKey DraculaGray
   hi! link LspReferenceText DraculaSelection
   hi! link LspReferenceRead DraculaSelection
   hi! link LspReferenceWrite DraculaSelection
@@ -295,7 +298,7 @@ if has('nvim')
 
   hi! link WinSeparator DraculaWinSeparator
 else
-  hi! link SpecialKey DraculaPink
+  hi! link SpecialKey DraculaGray
 endif
 
 hi! link Comment DraculaComment


### PR DESCRIPTION
I use UTF-8 chars for my custom `listchars` for `tabs` and `trail`. For example, in C code with tabs indents, `DraculaPink` is used for both `SpecialKey` and C keywords so it gets hard to read the code. I decided to switch `SpecialKey` color to something like gray color with a bit less blue component in it to distinguish it (it's not perfect though) from the comments color. Maybe this change might be useful.

The default scheme:
![pink](https://user-images.githubusercontent.com/21184954/235226724-bb46e18a-efce-4edd-96d4-0e1b59718407.png)

With gray color:
![gray](https://user-images.githubusercontent.com/21184954/235226784-65ab9b73-ebdd-411d-9b2f-37f14e40525c.png)
