### PR TITLE
Disable background highlighting of `DraculaDiffDelete` when appropriate

### DIFF
--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -57,17 +57,17 @@ if has('nvim-0.5') && luaeval("pcall(require, 'gitsigns')")
   hi! link GitSignsChangeLn DiffChange
   hi! link GitSignsChangeNr DiffChange
 
-	" Manually set `GitSignsDelete` when in a terminal where `g:dracula_colorterm`
-	" is false to remain consistent with the other GitSigns highlights.
-	if g:dracula_colorterm || has('gui_running') 
-		hi! link GitSignsDelete DiffDelete
-	else
-		hi! link GitSignsDelete DraculaRed
-	endif
-	" GitSignsDeleteLn and GitSignsDeleteNr should always match
-	" whatever GitSignsDelete is set to.
-	hi! link GitSignsDeleteLn	GitSignsDelete
-	hi! link GitSignsDeleteNr	GitSignsDelete
+  " Manually set `GitSignsDelete` when in a terminal where `g:dracula_colorterm`
+  " is false to remain consistent with the other GitSigns highlights.
+  if g:dracula_colorterm || has('gui_running') 
+    hi! link GitSignsDelete DiffDelete
+  else
+    hi! link GitSignsDelete DraculaRed
+  endif
+  " GitSignsDeleteLn and GitSignsDeleteNr should always match
+  " whatever GitSignsDelete is set to.
+  hi! link GitSignsDeleteLn GitSignsDelete
+  hi! link GitSignsDeleteNr GitSignsDelete
 endif
 " }}}
 " Tree-sitter: {{{

--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -56,9 +56,18 @@ if has('nvim-0.5') && luaeval("pcall(require, 'gitsigns')")
   hi! link GitSignsChange   DiffChange
   hi! link GitSignsChangeLn DiffChange
   hi! link GitSignsChangeNr DiffChange
-  hi! link GitSignsDelete   DiffDelete
-  hi! link GitSignsDeleteLn DiffDelete
-  hi! link GitSignsDeleteNr DiffDelete
+
+	" Manually set `GitSignsDelete` when in a terminal where `g:dracula_colorterm`
+	" is false to remain consistent with the other GitSigns highlights.
+	if g:dracula_colorterm || has('gui_running') 
+		hi! link GitSignsDelete DiffDelete
+	else
+		hi! link GitSignsDelete DraculaRed
+	endif
+	" GitSignsDeleteLn and GitSignsDeleteNr should always match
+	" whatever GitSignsDelete is set to.
+	hi! link GitSignsDeleteLn	GitSignsDelete
+	hi! link GitSignsDeleteNr	GitSignsDelete
 endif
 " }}}
 " Tree-sitter: {{{


### PR DESCRIPTION
Disable the background highlight for the `DraculaDiffDelete` group when:
- `g:dracula_colorterm` is false, AND
- `has('gui_running')` is false

<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->
Before:
<img width="1440" alt="Screenshot 2023-05-25 at 11 26 25 AM" src="https://github.com/dracula/vim/assets/44714422/73873259-2d5d-4476-ad41-820f33b334d5">

After:
<img width="1440" alt="Screenshot 2023-05-25 at 11 27 48 AM" src="https://github.com/dracula/vim/assets/44714422/e373b98e-4da3-415c-af52-2552140a015d">
