### PR TITLE
Update GitSignsDelete highlight group to always link to DraculaRed

### DIFF
--- a/after/plugin/dracula.vim
+++ b/after/plugin/dracula.vim
@@ -57,17 +57,9 @@ if has('nvim-0.5') && luaeval("pcall(require, 'gitsigns')")
   hi! link GitSignsChangeLn DiffChange
   hi! link GitSignsChangeNr DiffChange
 
-  " Manually set `GitSignsDelete` when in a terminal where `g:dracula_colorterm`
-  " is false to remain consistent with the other GitSigns highlights.
-  if g:dracula_colorterm || has('gui_running') 
-    hi! link GitSignsDelete DiffDelete
-  else
-    hi! link GitSignsDelete DraculaRed
-  endif
-  " GitSignsDeleteLn and GitSignsDeleteNr should always match
-  " whatever GitSignsDelete is set to.
-  hi! link GitSignsDeleteLn GitSignsDelete
-  hi! link GitSignsDeleteNr GitSignsDelete
+  hi! link GitSignsDelete   DraculaRed
+  hi! link GitSignsDeleteLn DraculaRed
+  hi! link GitSignsDeleteNr DraculaRed
 endif
 " }}}
 " Tree-sitter: {{{


### PR DESCRIPTION
This is an add-on to the changes made in #306. Upon further usage I noticed that the gutter column used by the `GitSigns` plugin never uses the darker background that the `GitDiffDelete` highlight group uses. 

`GitSignsDelete` (new in #306) was set to link to `DraculaRed` _unless_ the user was in a GUI or had `g:colorterm` set true. However, in both of those cases the correct background to use still isn't that provided by `GitDiffDelete`.

I've updated the `GitSignsDelete` highlight group to **always** link to `DraculaRed` to keep it consistent with the background of the other signs as well as the column as a whole.

