### PR TITLE
Add DraculaInlayHint and link from LspInlayHint

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -210,7 +210,7 @@ else
 endif
 
 call s:h('DraculaDiffText', s:bg, s:orange)
-call s:h('DraculaInlayHint', s:comment, s:bgdark, [s:attrs.italic])
+call s:h('DraculaInlayHint', s:comment, s:bgdark)
 
 " }}}2
 

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -210,6 +210,7 @@ else
 endif
 
 call s:h('DraculaDiffText', s:bg, s:orange)
+call s:h('DraculaInlayHint', s:comment, s:bgdark, [s:attrs.italic])
 
 " }}}2
 
@@ -283,6 +284,7 @@ if has('nvim')
   hi! link LspDiagnosticsUnderlineHint DiagnosticUnderlineHint
   hi! link LspDiagnosticsUnderlineInformation DiagnosticUnderlineInfo
   hi! link LspDiagnosticsUnderlineWarning DiagnosticUnderlineWarn
+  hi! link LspInlayHint DraculaInlayHint
 
   hi! link DiagnosticInfo DraculaCyan
   hi! link DiagnosticHint DraculaCyan


### PR DESCRIPTION
The default display of the new LspInlayHint highlight group is difficult to read.  I added a new Dracula group and linked it to LspInlayHint.  I think this is pretty easy on the eyes and is similar to what the Dracula theme does on CLion.

Before:
![Screenshot from 2023-08-12 16-27-26](https://github.com/dracula/vim/assets/2708290/3bdd7ddb-9bfb-42f2-ad5d-912e853d4030)

After:
![Screenshot from 2023-08-12 16-26-55](https://github.com/dracula/vim/assets/2708290/3a3a777b-e048-4242-b56c-d54803f9ec02)
