### PR TITLE
(nvim) add LSP semantic tokens

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -296,6 +296,24 @@ if has('nvim')
   hi! link DiagnosticUnderlineWarn DraculaWarnLine
 
   hi! link WinSeparator DraculaWinSeparator
+
+  if has('nvim-0.9')
+    hi! link  @lsp.type.class DraculaCyan
+    hi! link  @lsp.type.decorator DraculaGreen
+    hi! link  @lsp.type.enum DraculaCyan
+    hi! link  @lsp.type.enumMember DraculaPurple
+    hi! link  @lsp.type.function DraculaGreen
+    hi! link  @lsp.type.interface DraculaCyan
+    hi! link  @lsp.type.macro DraculaCyan
+    hi! link  @lsp.type.method DraculaGreen
+    hi! link  @lsp.type.namespace DraculaCyan
+    hi! link  @lsp.type.parameter DraculaOrangeItalic
+    hi! link  @lsp.type.property DraculaOrange
+    hi! link  @lsp.type.struct DraculaCyan
+    hi! link  @lsp.type.type DraculaCyanItalic
+    hi! link  @lsp.type.typeParameter DraculaPink
+    hi! link  @lsp.type.variable DraculaFg
+  endif
 else
   hi! link SpecialKey DraculaPink
 endif


### PR DESCRIPTION
Neovim stabilized their highlight groups for LSP semantic tokens in [#22022](https://github.com/neovim/neovim/pull/22022). This PR adds the highlight groups to this plugin and changes some defaults.

Changes:
| Group               | Linked default | This PR             |
| ------------------- | ---------------| ------------------- |
| @lsp.type.class     | DraculaPink    | DraculaCyan         |
| @lsp.type.enum      | DraculaPink    | DraculaCyan         |
| @lsp.type.interface | DraculaPink    | DraculaCyan         |
| @lsp.type.macro     | DraculaPink    | DraculaCyan         |
| @lsp.type.namespace | DraculaPink    | DraculaCyan         |
| @lsp.type.parameter | DraculaFg      | DraculaOrangeItalic |
| @lsp.type.property  | DraculaFg      | DraculaOrange       |
| @lsp.type.struct    | DraculaPink    | DraculaCyan         |

resolves #290

<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->

