### PR TITLE
colors: support new PmenuMatch{,Sel}

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -255,6 +255,8 @@ hi! link Pmenu        DraculaBgDark
 hi! link PmenuSbar    DraculaBgDark
 hi! link PmenuSel     DraculaSelection
 hi! link PmenuThumb   DraculaSelection
+call s:h('PmenuMatch', s:cyan, s:bgdark)
+call s:h('PmenuMatchSel', s:cyan, s:selection)
 hi! link Question     DraculaFgBold
 hi! link Search       DraculaSearch
 call s:h('SignColumn', s:comment)


### PR DESCRIPTION
I've used pink colors for matched text, but kept backgrounds the same.

These features were implemented by
https://github.com/vim/vim/commit/40c1c3317d92f8c2adadf744fab72e4458e2a9fa, and there is ongoing discussion about some edge-cases and odd behavior IIUC.
