### PR TITLE
Link NormalFloat to Pmenu

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -304,6 +304,7 @@ if has('nvim')
   hi! link DiagnosticUnderlineWarn DraculaWarnLine
 
   hi! link WinSeparator DraculaWinSeparator
+  hi! link NormalFloat Pmenu
 
   if has('nvim-0.9')
     hi! link  @lsp.type.class DraculaCyan


### PR DESCRIPTION
Prior to Neovim 0.10.0, NormalFloat was linked to Pmenu. Neovim 0.10.0 changed this to support their new default colors. This patch reapplies the old behavior.

resolves dracula/vim#322

Before:
![1721584912_grimshot](https://github.com/user-attachments/assets/d6e29d54-bdd0-43bc-8d5f-b9dded8a5af2)

After:
![1721584945_grimshot](https://github.com/user-attachments/assets/87736df6-2fce-4226-9acb-e193a44a9829)
