### PR TITLE
Add support for blink.cmp

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -995,6 +995,34 @@ if has('nvim')
   hi! link GitSignsDeleteNr DraculaRed
   " }}}
 
+  " Saghen/blink.cmp {{{
+  hi! link BlinkCmpKindText DraculaFg
+  hi! link BlinkCmpKindMethod Function
+  hi! link BlinkCmpFunction Function
+  hi! link BlinkCmpKindConstructor DraculaCyan
+  hi! link BlinkCmpKindField DraculaOrange
+  hi! link BlinkCmpKindVariable DraculaPurpleItalic
+  hi! link BlinkCmpKindClass DraculaCyan
+  hi! link BlinkCmpKindInterface DraculaCyan
+  hi! link BlinkCmpKindModule DraculaYellow
+  hi! link BlinkCmpKindProperty DraculaPink
+  hi! link BlinkCmpKindUnit DraculaFg
+  hi! link BlinkCmpKindValue DraculaYellow
+  hi! link BlinkCmpKindEnum DraculaPink
+  hi! link BlinkCmpKindKeyword DraculaPink
+  hi! link BlinkCmpKindSnippet DraculaFg
+  hi! link BlinkCmpKindColor DraculaYellow
+  hi! link BlinkCmpKindFile DraculaYellow
+  hi! link BlinkCmpKindReference DraculaOrange
+  hi! link BlinkCmpKindFolder DraculaYellow
+  hi! link BlinkCmpKindEnumMember DraculaPurple
+  hi! link BlinkCmpKindConstant DraculaPurple
+  hi! link BlinkCmpKindStruct DraculaPink
+  hi! link BlinkCmpKindEvent DraculaFg
+  hi! link BlinkCmpKindOperator DraculaPink
+  hi! link BlinkCmpKindTypeParameter DraculaCyan
+  " }}}
+
 endif
 " }}}
 


### PR DESCRIPTION
[blink.cmp](https://github.com/Saghen/blink.cmp) has officially released 1.0. With the API now stable, it would be nice if dracula provided support for its highlight groups. This PR provides the definitions for the blink item highlight groups (they're defined like the ones for `nvim-cmp`). This allows users to use blink's highlight groups directly instead of having to rely on the ones from `nvim-cmp`.