### PR TITLE
colors: support nvim-tree.lua and mini.icons

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -1024,7 +1024,6 @@ if has('nvim')
   " }}}
 
   " nvim-tree/nvim-tree.lua {{{
-  hi! NvimTreeSpecialFile gui=bold,underline
   hi! link NvimTreeEmptyFolderName DraculaPurple
   hi! link NvimTreeExecFile DraculaGreen
   hi! link NvimTreeFolderIcon DraculaPurple

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -1023,6 +1023,35 @@ if has('nvim')
   hi! link BlinkCmpKindTypeParameter DraculaCyan
   " }}}
 
+  " nvim-tree/nvim-tree.lua {{{
+  hi! NvimTreeSpecialFile gui=bold,underline
+  hi! link NvimTreeEmptyFolderName DraculaPurple
+  hi! link NvimTreeExecFile DraculaGreen
+  hi! link NvimTreeFolderIcon DraculaPurple
+  hi! link NvimTreeFolderName DraculaPurpleBold
+  hi! link NvimTreeGitDeleted DraculaRed
+  hi! link NvimTreeGitDirty DraculaOrange
+  hi! link NvimTreeGitNew DraculaGreen
+  hi! link NvimTreeGitStaged DraculaGreen
+  hi! link NvimTreeImageFile DraculaPink
+  hi! link NvimTreeIndentMarker DraculaComment
+  hi! link NvimTreeOpenedFolderName DraculaPurpleBold
+  hi! link NvimTreeRootFolder DraculaPurpleItalic
+  hi! link NvimTreeSymlink DraculaCyan
+  hi! link NvimTreeSymlinkFolderName DraculaPurple
+  " }}}
+
+  " nvim-mini/mini.icons {{{
+  hi! link MiniIconsAzure DraculaCyan
+  hi! link MiniIconsBlue DraculaCyan
+  hi! link MiniIconsCyan DraculaCyan
+  hi! link MiniIconsGreen DraculaGreen
+  hi! link MiniIconsGrey DraculaFg
+  hi! link MiniIconsOrange DraculaOrange
+  hi! link MiniIconsPurple DraculaPurple
+  hi! link MiniIconsRed DraculaRed
+  hi! link MiniIconsYellow DraculaYellow
+  " }}}
 endif
 " }}}
 


### PR DESCRIPTION
Made nvim-tree colors more aligned with the colors used by gitsigns and terminal's ls command.

Added explicit links between mini.icon's and dracula's color names group to fix some mismatches (like .lua, .js/.py icon colors).

<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->

Screenshot before and after:

<img width="2060" height="1630" alt="nvimtree" src="https://github.com/user-attachments/assets/89c2db37-f170-4f72-8b34-836a6219982a" />