### PR TITLE
feat: support mini.statusline plugin

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -170,30 +170,35 @@ call s:h('DraculaSubtle', s:subtle)
 
 call s:h('DraculaCyan', s:cyan)
 call s:h('DraculaCyanItalic', s:cyan, s:none, [s:attrs.italic])
+call s:h('DraculaCyanInverse', s:cyan, s:bg, [s:attrs.inverse])
 
 call s:h('DraculaGreen', s:green)
 call s:h('DraculaGreenBold', s:green, s:none, [s:attrs.bold])
 call s:h('DraculaGreenItalic', s:green, s:none, [s:attrs.italic])
 call s:h('DraculaGreenItalicUnderline', s:green, s:none, [s:attrs.italic, s:attrs.underline])
+call s:h('DraculaGreenInverse', s:green, s:bg, [s:attrs.inverse])
 
 call s:h('DraculaOrange', s:orange)
 call s:h('DraculaOrangeBold', s:orange, s:none, [s:attrs.bold])
 call s:h('DraculaOrangeItalic', s:orange, s:none, [s:attrs.italic])
 call s:h('DraculaOrangeBoldItalic', s:orange, s:none, [s:attrs.bold, s:attrs.italic])
-call s:h('DraculaOrangeInverse', s:bg, s:orange)
+call s:h('DraculaOrangeInverse', s:orange, s:bg, [s:attrs.inverse])
 
 call s:h('DraculaPink', s:pink)
 call s:h('DraculaPinkItalic', s:pink, s:none, [s:attrs.italic])
+call s:h('DraculaPinkInverse', s:pink, s:bg, [s:attrs.inverse])
 
 call s:h('DraculaPurple', s:purple)
 call s:h('DraculaPurpleBold', s:purple, s:none, [s:attrs.bold])
 call s:h('DraculaPurpleItalic', s:purple, s:none, [s:attrs.italic])
+call s:h('DraculaPurpleInverse', s:purple, s:bg, [s:attrs.inverse])
 
 call s:h('DraculaRed', s:red)
-call s:h('DraculaRedInverse', s:fg, s:red)
+call s:h('DraculaRedInverse', s:red, s:bg, [s:attrs.inverse])
 
 call s:h('DraculaYellow', s:yellow)
 call s:h('DraculaYellowItalic', s:yellow, s:none, [s:attrs.italic])
+call s:h('DraculaYellowInverse', s:yellow, s:bg, [s:attrs.inverse])
 
 call s:h('DraculaError', s:red, s:none, [], s:red)
 
@@ -202,7 +207,6 @@ call s:h('DraculaWarnLine', s:none, s:none, [s:attrs.undercurl], s:orange)
 call s:h('DraculaInfoLine', s:none, s:none, [s:attrs.undercurl], s:cyan)
 
 call s:h('DraculaTodo', s:cyan, s:none, [s:attrs.bold, s:attrs.inverse])
-call s:h('DraculaSearch', s:green, s:none, [s:attrs.inverse])
 call s:h('DraculaBoundary', s:comment, s:bgdark)
 call s:h('DraculaWinSeparator', s:comment, s:bgdark)
 call s:h('DraculaLink', s:cyan, s:none, [s:attrs.underline])
@@ -233,6 +237,9 @@ call s:h('StatusLineTerm', s:none, s:bglighter, [s:attrs.bold])
 call s:h('StatusLineTermNC', s:none, s:bglight)
 call s:h('WildMenu', s:bg, s:purple, [s:attrs.bold])
 call s:h('CursorLine', s:none, s:subtle)
+
+" Maintain the DraculaSearch group for backwards compatibility.
+hi! link DraculaSearch DraculaGreenInverse
 
 hi! link ColorColumn  DraculaBgDark
 hi! link CursorColumn CursorLine

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -1062,6 +1062,19 @@ if has('nvim')
   hi! link MiniIconsRed DraculaRed
   hi! link MiniIconsYellow DraculaYellow
   " }}}
+
+  " nvim-mini/mini.statusline {{{
+  hi! link MiniStatuslineDevInfo StatusLine
+  hi! link MiniStatuslineFileInfo StatusLine
+  hi! link MiniStatuslineFilename StatusLineNC
+  hi! link MiniStatuslineInactive StatusLineNC
+  hi! link MiniStatuslineModeCommand DraculaCyanInverse
+  hi! link MiniStatuslineModeInsert DraculaGreenInverse
+  hi! link MiniStatuslineModeNormal DraculaPurpleInverse
+  hi! link MiniStatuslineModeOther DraculaGreenInverse
+  hi! link MiniStatuslineModeReplace DraculaOrangeInverse
+  hi! link MiniStatuslineModeVisual DraculaYellowInverse
+  " }}}
 endif
 " }}}
 


### PR DESCRIPTION
<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->

Fixes #335 

I've tried to replicate the airline theme for the mode colors and adhere to the defaults of the mini.statusline plugin for the rest. Airline doesn't support a separate highlight group for command mode, so I've chosen the cyan color.

Documentation for the highlight groups: https://github.com/nvim-mini/mini.nvim/blob/cad365c212fb1e332cb93fa8f72697125799d00a/doc/mini-statusline.txt#L48

The screenshots below are using the default configuration for the mini.statusline plugin.

---

<img width="1250" height="941" alt="Screenshot 2026-03-14 at 11 58 20 AM" src="https://github.com/user-attachments/assets/eb45b6fb-925b-4d0a-bcee-4798ccc1b6e9" />

<img width="1250" height="941" alt="Screenshot 2026-03-14 at 11 58 28 AM" src="https://github.com/user-attachments/assets/a1ee81d2-d65e-4125-a8b1-893656339bfd" />

<img width="1250" height="941" alt="Screenshot 2026-03-14 at 11 59 13 AM" src="https://github.com/user-attachments/assets/6fa1fe0c-d65a-4b40-ba6e-6245e2cfa154" />

<img width="1250" height="941" alt="Screenshot 2026-03-14 at 11 58 40 AM" src="https://github.com/user-attachments/assets/4c5e6974-d245-4371-802b-9d5b67eee18a" />

<img width="1250" height="941" alt="Screenshot 2026-03-14 at 11 58 55 AM" src="https://github.com/user-attachments/assets/60832d84-1be2-4d54-b923-18591cdf0b6f" />

<img width="1250" height="941" alt="Screenshot 2026-03-14 at 11 59 36 AM" src="https://github.com/user-attachments/assets/92977ba2-5b97-4609-9d9f-8768b1a235b0" />

<img width="1250" height="941" alt="Screenshot 2026-03-14 at 12 04 46 PM" src="https://github.com/user-attachments/assets/dc9e3cd6-248e-4c5c-8032-20494749c728" />

<img width="1250" height="1039" alt="Screenshot 2026-03-14 at 12 10 51 PM" src="https://github.com/user-attachments/assets/6dfd97d7-af30-407a-ac46-ec928e3d8c36" />