### PR TITLE
feat: support added, changed, and removed highlight groups

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -331,6 +331,10 @@ hi! link Comment DraculaComment
 hi! link Underlined DraculaFgUnderline
 hi! link Todo DraculaTodo
 
+hi! link Added DiffAdded
+hi! link Changed DiffChange
+hi! link Removed DiffRemoved
+
 hi! link Error DraculaError
 hi! link SpellBad DraculaErrorLine
 hi! link SpellLocal DraculaWarnLine


### PR DESCRIPTION
<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->

The Vim `syntax.txt` help document [lists three preferred highlight group names](https://vimhelp.org/syntax.txt.html#:~:text=%2AAdded%20added%20line%20in%20a%20diff%20%2AChanged%20changed%20line%20in%20a%20diff%20%2ARemoved%20removed%20line%20in%20a%20diff) that we don't currently support: `Added`, `Changed`, and `Removed`.

Since these groups are preferred names, some plugins (e.g. `mini.diff`) use them by default. Defining these groups in the dracula color scheme should improve out-of-the-box plugin support.

<img width="1250" height="1039" alt="Screenshot 2026-03-14 at 2 46 48 PM" src="https://github.com/user-attachments/assets/55b0c1fb-f794-4b17-9323-bef75116991c" />
