### PR TITLE
feat: support snacks picker highlights

### DIFF
--- a/colors/dracula_base.vim
+++ b/colors/dracula_base.vim
@@ -1034,6 +1034,37 @@ if has('nvim')
   hi! link BlinkCmpKindTypeParameter DraculaCyan
   " }}}
 
+  " folke/snacks.nvim {{{
+  hi! link SnacksPicker DraculaBgDark
+  hi! link SnacksPickerBorder DraculaBoundary
+  hi! link SnacksPickerTitle DraculaPurpleBold
+  hi! link SnacksPickerInput DraculaBgDark
+  hi! link SnacksPickerInputBorder DraculaBoundary
+  hi! link SnacksPickerInputTitle DraculaPurpleBold
+  hi! link SnacksPickerListCursorLine DraculaSelection
+
+  hi! link SnacksPickerPrompt DraculaPurple
+  hi! link SnacksPickerMatch DraculaCyan
+  hi! link SnacksPickerSelected DraculaPink
+  hi! link SnacksPickerUnselected DraculaSubtle
+
+  hi! link SnacksPickerFile DraculaFg
+  hi! link SnacksPickerDirectory Directory
+  hi! link SnacksPickerDir DraculaComment
+  hi! link SnacksPickerPathHidden DraculaComment
+  hi! link SnacksPickerPathIgnored DraculaComment
+
+  hi! link SnacksPickerGitStatusAdded DiffAdd
+  hi! link SnacksPickerGitStatusModified DiagnosticWarn
+  hi! link SnacksPickerGitStatusDeleted DiffDelete
+  hi! link SnacksPickerGitStatusRenamed DraculaYellow
+  hi! link SnacksPickerGitStatusCopied DraculaYellow
+  hi! link SnacksPickerGitStatusUntracked DraculaGreen
+  hi! link SnacksPickerGitStatusIgnored DraculaComment
+  hi! link SnacksPickerGitStatusUnmerged DiagnosticError
+  hi! link SnacksPickerGitStatusStaged DiagnosticHint
+  " }}}
+
   " nvim-tree/nvim-tree.lua {{{
   hi! link NvimTreeEmptyFolderName DraculaPurple
   hi! link NvimTreeExecFile DraculaGreen


### PR DESCRIPTION
## Summary

- Add Dracula highlight links for `folke/snacks.nvim` picker UI groups.
- Improve picker row selection, match text, file/path labels, and git status colors.
- Keep the integration consistent by linking to existing Dracula highlight groups.

## Verification

- Loaded the colorscheme successfully in Neovim:

```sh
nvim --headless -u NONE +'set rtp^=.' +'set termguicolors' +'colorscheme dracula' +'quit'
```

- Verified Snacks picker highlight links with a reproducible local config using `folke/snacks.nvim` and `nvim-mini/mini.icons`:

```text
SnacksPickerListCursorLine -> DraculaSelection
SnacksPickerMatch -> DraculaCyan
SnacksPickerSelected -> DraculaPink
SnacksPickerFile -> DraculaFg
SnacksPickerDirectory -> Directory
SnacksPickerGitStatusModified -> DiagnosticWarn
```

- Manually inspected the picker UI with icons enabled.

<img width="3316" height="1966" alt="image" src="https://github.com/user-attachments/assets/fdaad5b1-9f40-4f14-90a4-290c862b294c" />
